### PR TITLE
Add simple benchmark of parsing performance

### DIFF
--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -29,6 +29,11 @@ test = ["diff", "rayon"]
 [dev-dependencies]
 diff = "0.1.12"
 rayon = "1.5"
+criterion = "0.3"
+
+[[bench]]
+name = "parsing"
+harness = false
 
 [[bin]]
 name = "fea-rs"

--- a/fea-rs/benches/parsing.rs
+++ b/fea-rs/benches/parsing.rs
@@ -1,0 +1,29 @@
+//! A very simple benchmark for the parser
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+const DEVA: &str = include_str!("../test-data/real-files/plex_devanagari.fea");
+const LATN: &str = include_str!("../test-data/real-files/roboto-regular.fea");
+const ARAB: &str = include_str!("../test-data/real-files/tajawal-regular.fea");
+
+fn parse_source(source: &fea_rs::Source) -> fea_rs::Node {
+    fea_rs::parse_src(source, None).0
+}
+
+fn parsing(c: &mut Criterion) {
+    let deva = fea_rs::Source::from_text(DEVA);
+    let latn = fea_rs::Source::from_text(LATN);
+    let arab = fea_rs::Source::from_text(ARAB);
+    c.bench_function("parse plex-devenagari", |b| {
+        b.iter(|| parse_source(black_box(&deva)))
+    });
+    c.bench_function("parse roboto-regular", |b| {
+        b.iter(|| parse_source(black_box(&latn)))
+    });
+    c.bench_function("parse tajawal-regular", |b| {
+        b.iter(|| parse_source(black_box(&arab)))
+    });
+}
+
+criterion_group!(benches, parsing);
+criterion_main!(benches);


### PR DESCRIPTION
I want this in place so I can evaluate the impact of reparsing for
contextual rules.