### PR TITLE
Node rewriting

### DIFF
--- a/fea-rs/src/parse/context.rs
+++ b/fea-rs/src/parse/context.rs
@@ -337,8 +337,10 @@ pub fn parse_src(
     glyph_map: Option<&GlyphMap>,
 ) -> (Node, Vec<Diagnostic>, Vec<IncludeStatement>) {
     let mut sink = AstSink::new(src.text(), src.id(), glyph_map);
-    let mut parser = Parser::new(src.text(), &mut sink);
-    super::grammar::root(&mut parser);
+    {
+        let mut parser = Parser::new(src.text(), &mut sink);
+        super::grammar::root(&mut parser);
+    }
     sink.finish()
 }
 

--- a/fea-rs/src/parse/grammar/gpos.rs
+++ b/fea-rs/src/parse/grammar/gpos.rs
@@ -181,7 +181,7 @@ fn finish_chain_rule(parser: &mut Parser, recovery: TokenSet) -> AstKind {
     //TODO: we should be done? but we also don't know how this works? inline rules
     //are weird for gpos I need to rethink this
     if parser.expect_semi() {
-        AstKind::GposType8
+        AstKind::GposNodeNeedsRewrite
     } else {
         AstKind::GposNode
     }

--- a/fea-rs/src/parse/grammar/gpos.rs
+++ b/fea-rs/src/parse/grammar/gpos.rs
@@ -89,7 +89,7 @@ fn parse_ignore(parser: &mut Parser, recovery: TokenSet) -> AstKind {
     assert!(parser.eat(Kind::PosKw));
 
     if super::expect_ignore_pattern_body(parser, recovery) {
-        AstKind::GposIgnore
+        AstKind::GposNodeNeedsRewrite
     } else {
         AstKind::GposNode
     }

--- a/fea-rs/src/parse/grammar/gsub.rs
+++ b/fea-rs/src/parse/grammar/gsub.rs
@@ -149,7 +149,7 @@ fn parse_ignore(parser: &mut Parser, recovery: TokenSet) -> AstKind {
     assert!(parser.eat(Kind::IgnoreKw));
     assert!(parser.eat(Kind::SubKw));
     if super::expect_ignore_pattern_body(parser, recovery) {
-        AstKind::GsubIgnore
+        AstKind::GsubNodeNeedsRewrite
     } else {
         AstKind::GsubNode
     }

--- a/fea-rs/src/parse/grammar/gsub.rs
+++ b/fea-rs/src/parse/grammar/gsub.rs
@@ -157,15 +157,13 @@ fn parse_ignore(parser: &mut Parser, recovery: TokenSet) -> AstKind {
 
 fn parse_rsub(parser: &mut Parser, recovery: TokenSet) -> AstKind {
     assert!(parser.eat(Kind::RsubKw));
-    if !glyph::expect_glyph_or_glyph_class(parser, recovery) {
-        parser.eat_until(recovery);
-        return AstKind::GsubNode;
-    }
+    let recovery = recovery.add(Kind::Semi);
 
     super::greedy(glyph::eat_glyph_or_glyph_class)(parser, recovery);
 
     if !parser.expect(Kind::SingleQuote) {
         parser.eat_until(recovery);
+        parser.expect_semi();
         return AstKind::GsubNode;
     }
 
@@ -174,13 +172,14 @@ fn parse_rsub(parser: &mut Parser, recovery: TokenSet) -> AstKind {
     if parser.matches(0, Kind::SingleQuote) {
         parser.err("reversesub rule can have only one marked glyph");
         parser.eat_until(recovery);
+        parser.expect_semi();
         return AstKind::GsubNode;
     }
     if parser.eat(Kind::ByKw) {
         glyph::expect_glyph_or_glyph_class(parser, recovery);
     }
     parser.expect_semi();
-    AstKind::GsubType8
+    AstKind::GsubNodeNeedsRewrite
 }
 
 #[cfg(test)]

--- a/fea-rs/src/parse/grammar/gsub.rs
+++ b/fea-rs/src/parse/grammar/gsub.rs
@@ -23,6 +23,7 @@ pub(crate) fn gsub(parser: &mut Parser, recovery: TokenSet) {
         if parser.matches(0, Kind::RsubKw) {
             return parse_rsub(parser, recovery);
         }
+
         assert!(parser.eat(Kind::SubKw));
 
         let is_class = matches!(parser.nth(0).kind, Kind::LSquare | Kind::NamedGlyphClass);
@@ -93,6 +94,7 @@ pub(crate) fn gsub(parser: &mut Parser, recovery: TokenSet) {
     }
 
     parser.eat_trivia();
+
     parser.start_node(AstKind::GsubNode);
     let kind = gsub_body(parser, recovery);
     parser.finish_and_remap_node(kind);
@@ -137,7 +139,7 @@ fn finish_chain_rule(parser: &mut Parser, recovery: TokenSet) -> AstKind {
     }
 
     if parser.expect_semi() {
-        AstKind::GsubType6
+        AstKind::GsubNodeNeedsRewrite
     } else {
         AstKind::GsubNode
     }

--- a/fea-rs/src/parse/grammar/mod.rs
+++ b/fea-rs/src/parse/grammar/mod.rs
@@ -240,7 +240,7 @@ fn anonymous(parser: &mut Parser) {
 
 /// Common between gpos/gsub
 fn expect_ignore_pattern_body(parser: &mut Parser, recovery: TokenSet) -> bool {
-    let recovery = recovery.add(Kind::Semi.into());
+    let recovery = recovery.add(Kind::Semi);
     if !eat_ignore_statement_item(parser, recovery) {
         parser.err_recover("Expected ignore pattern", recovery);
         parser.eat_until(recovery);
@@ -316,7 +316,7 @@ fn debug_parse_output(
         if !err_str.is_empty() {
             err_str.push('\n');
         }
-        crate::util::highlighting::write_diagnostic(&mut err_str, &err, &source, Some(80));
+        crate::util::highlighting::write_diagnostic(&mut err_str, err, &source, Some(80));
     }
     (node, errs, err_str)
 }

--- a/fea-rs/src/parse/parser.rs
+++ b/fea-rs/src/parse/parser.rs
@@ -9,7 +9,7 @@ use super::{
     lexer::{Kind as LexemeKind, Lexeme, Lexer, TokenSet},
     FileId,
 };
-use crate::token_tree::{Kind, TreeSink};
+use crate::token_tree::{AstSink, Kind};
 
 use crate::diagnostic::Diagnostic;
 
@@ -24,9 +24,10 @@ const LOOKAHEAD_MAX: usize = LOOKAHEAD - 1;
 ///
 /// This type does not implement the parsing *logic*; it is driven by various
 /// functions defined in the [`grammar`] module.
-pub struct Parser<'a> {
+pub struct Parser<'a, 'b> {
     lexer: Lexer<'a>,
-    sink: &'a mut dyn TreeSink,
+    // these lifetimes are a hangover from a previous design.
+    sink: &'b mut AstSink<'a>,
     text: &'a str,
     buf: [PendingToken; LOOKAHEAD],
 }
@@ -72,8 +73,8 @@ impl PendingToken {
     };
 }
 
-impl<'a> Parser<'a> {
-    pub(crate) fn new(text: &'a str, sink: &'a mut dyn TreeSink) -> Self {
+impl<'b, 'a> Parser<'a, 'b> {
+    pub(crate) fn new(text: &'a str, sink: &'b mut AstSink<'a>) -> Self {
         let mut this = Parser {
             lexer: Lexer::new(text),
             sink,

--- a/fea-rs/src/tests/parse.rs
+++ b/fea-rs/src/tests/parse.rs
@@ -124,7 +124,7 @@ fn compare_to_expected_output(output: &str, src_path: &Path, cmp_ext: &str) -> R
     };
 
     if expected != output {
-        let diff_percent = test_utils::compute_diff_percentage(&expected, &output);
+        let diff_percent = test_utils::compute_diff_percentage(&expected, output);
         return Err(Failure {
             path: src_path.to_owned(),
             reason: Reason::CompareFail {

--- a/fea-rs/src/token_tree.rs
+++ b/fea-rs/src/token_tree.rs
@@ -180,6 +180,9 @@ impl<'a> AstSink<'a> {
             Kind::GsubNodeNeedsRewrite => {
                 Some(self.rewrite_current_node(rewrite::reparse_contextual_sub_rule))
             }
+            Kind::GposNodeNeedsRewrite => {
+                Some(self.rewrite_current_node(rewrite::reparse_contextual_pos_rule))
+            }
             _ => None,
         }
     }

--- a/fea-rs/src/token_tree/rewrite.rs
+++ b/fea-rs/src/token_tree/rewrite.rs
@@ -133,7 +133,14 @@ pub(crate) fn reparse_contextual_sub_rule(rewriter: &mut ReparseCtx) -> Kind {
         reparse_ignore_rule(rewriter);
         return Kind::GsubIgnore;
     }
-    rewriter.expect(Kind::SubKw);
+
+    let rule_type = if rewriter.eat(Kind::RsubKw) {
+        Kind::GsubType8
+    } else {
+        rewriter.expect(Kind::SubKw);
+        Kind::GsubType6
+    };
+
     let mut any_lookups = false;
     // the backtrack sequence
     eat_non_marked_seqeunce(rewriter, Kind::BacktrackSequence);
@@ -170,7 +177,7 @@ pub(crate) fn reparse_contextual_sub_rule(rewriter: &mut ReparseCtx) -> Kind {
         eat_glyph_or_glyph_class(rewriter);
     }
     rewriter.expect_semi_and_nothing_else();
-    Kind::GsubType6
+    rule_type
 }
 
 pub(crate) fn reparse_contextual_pos_rule(rewriter: &mut ReparseCtx) -> Kind {

--- a/fea-rs/src/token_tree/rewrite.rs
+++ b/fea-rs/src/token_tree/rewrite.rs
@@ -1,0 +1,237 @@
+//! node rewriting.
+//!
+//! In certain instances (specifically the parsing of contextual and chaining-
+//! contextual rules) we can't parse the statement correctly without arbitrary
+//! lookahead. Instead, when we encounter a mark glyph we parse the statement
+//! naively, and then reparse it again afterwards.
+
+use crate::{parse::FileId, Diagnostic, NodeOrToken};
+
+use super::{AstSink, Kind};
+
+/// A transient context for rewriting nodes.
+///
+///
+/// This is sort of a toy version of the main parser, except that its atom
+/// is `NodeOrToken`, not lexemes.
+pub(crate) struct ReparseCtx<'a, 'b> {
+    pub(super) text_pos: usize,
+    pub(super) in_buf: &'a [NodeOrToken],
+    pub(super) sink: &'a mut AstSink<'b>,
+}
+
+impl<'a, 'b> ReparseCtx<'a, 'b> {
+    // nth non-trivia token
+    fn nth(&self, n: usize) -> Option<&NodeOrToken> {
+        self.in_buf.iter().filter(|t| !t.kind().is_trivia()).nth(n)
+    }
+
+    fn nth_kind(&self, n: usize) -> Kind {
+        self.nth(n).map(NodeOrToken::kind).unwrap_or(Kind::Eof)
+    }
+
+    fn matches(&self, n: usize, kind: Kind) -> bool {
+        self.nth(n).map(NodeOrToken::kind) == Some(kind)
+    }
+
+    // bump the next non-trivia token and any preceding trivia
+    fn eat_any(&mut self) {
+        self.eat_trivia();
+        self.bump_raw();
+    }
+
+    fn bump_raw(&mut self) {
+        if let Some((next, rest)) = self.in_buf.split_first() {
+            self.text_pos += next.text_len();
+            self.sink.push_raw(next.clone());
+            self.in_buf = rest;
+        }
+    }
+
+    fn eat_trivia(&mut self) {
+        while self
+            .in_buf
+            .get(0)
+            .map(|t| t.kind().is_trivia())
+            .unwrap_or(false)
+        {
+            self.bump_raw();
+        }
+    }
+
+    fn eat(&mut self, kind: Kind) -> bool {
+        if self.matches(0, kind) {
+            self.eat_trivia();
+            self.bump_raw();
+            return true;
+        }
+        false
+    }
+
+    fn expect(&mut self, kind: Kind) -> bool {
+        if !self.eat(kind) {
+            self.err_and_bump(format!("expected '{}' found '{}'", kind, self.nth_kind(0)));
+            return false;
+        }
+        true
+    }
+
+    fn expect_semi_and_nothing_else(&mut self) {
+        // we should have caught any major issues during the first parsing pass.
+        // as a precaution, we error if there are extra tokens and we have not already
+        // errored.
+
+        if !self.eat(Kind::Semi) && !self.sink.current_node_has_error() {
+            self.error("unexpected tokens in rewriter, please file a bug?");
+            while !self.in_buf.is_empty() {
+                self.bump_raw();
+            }
+        }
+    }
+
+    fn error(&mut self, message: impl Into<String>) {
+        self.eat_trivia();
+        let cur_len = self.nth(0).map(NodeOrToken::text_len).unwrap_or(0);
+        let range = self.text_pos..self.text_pos + cur_len;
+        let error = Diagnostic::error(FileId::CURRENT_FILE, range, message);
+        self.sink.error(error)
+    }
+
+    fn err_and_bump(&mut self, message: impl Into<String>) {
+        self.error(message);
+        self.eat_any();
+    }
+
+    fn in_node(&mut self, kind: Kind, f: impl FnOnce(&mut ReparseCtx<'a, 'b>)) {
+        self.eat_trivia();
+        self.sink.start_node(kind);
+        f(self);
+        self.sink.finish_node(None);
+    }
+
+    // for debugging
+    #[allow(dead_code)]
+    fn print_contents(&self) {
+        eprint!("reparse contents: '");
+        for item in self.in_buf {
+            match item {
+                NodeOrToken::Token(t) => eprint!("{}", t.text),
+                NodeOrToken::Node(node) => {
+                    for t in node.iter_tokens() {
+                        eprint!("{}", t.text);
+                    }
+                }
+            }
+        }
+        eprintln!("'");
+    }
+}
+
+pub(crate) fn reparse_contextual_sub_rule(rewriter: &mut ReparseCtx) -> Kind {
+    rewriter.expect(Kind::SubKw);
+    let mut any_lookups = false;
+    // the backtrack sequence
+    rewriter.in_node(Kind::BacktrackSequence, |rewriter| loop {
+        if rewriter.matches(1, Kind::SingleQuote) || !eat_glyph_or_glyph_class(rewriter) {
+            break;
+        }
+    });
+    // the contextual sequence
+    rewriter.in_node(Kind::ContextSequence, |rewriter| loop {
+        if !at_glyph_or_glyph_class(rewriter.nth_kind(0)) || !rewriter.matches(1, Kind::SingleQuote)
+        {
+            break;
+        }
+        rewriter.in_node(Kind::ContextGlyphNode, |rewriter| {
+            expect_glyph_or_glyph_class(rewriter);
+            rewriter.expect(Kind::SingleQuote);
+            any_lookups |= eat_contextual_lookups(rewriter);
+        })
+    });
+    // the lookahead sequence
+    rewriter.in_node(Kind::LookaheadSequence, |rewriter| {
+        while eat_glyph_or_glyph_class(rewriter) {
+            // continue
+        }
+    });
+    if rewriter.matches(0, Kind::ByKw) {
+        if any_lookups {
+            rewriter.error(
+                "cannot have inline ('by X') alongside explicit ('lookup MY_LOOKUP') statement",
+            );
+        }
+        rewriter.in_node(Kind::InlineSubNode, |rewriter| {
+            rewriter.expect(Kind::ByKw);
+            expect_glyph_or_glyph_class(rewriter);
+            if at_glyph_or_glyph_class(rewriter.nth_kind(0)) {
+                rewriter.err_and_bump("multiple substition rules cannot be specified inline.");
+            }
+        });
+    }
+    if rewriter.matches(0, Kind::FromKw) {
+        rewriter.err_and_bump("alternate substition rules cannot be specified inline");
+        eat_glyph_or_glyph_class(rewriter);
+    }
+    rewriter.expect_semi_and_nothing_else();
+    Kind::GsubType6
+}
+
+// the two lookups in "sub ka' lookup ONE lookup TWO b'"
+fn eat_contextual_lookups(rewriter: &mut ReparseCtx) -> bool {
+    if !eat_one_contextual_lookup(rewriter) {
+        return false;
+    }
+
+    while eat_one_contextual_lookup(rewriter) {
+        // continue
+    }
+    true
+}
+
+fn eat_one_contextual_lookup(rewriter: &mut ReparseCtx) -> bool {
+    rewriter.eat_trivia();
+    if rewriter.matches(0, Kind::LookupKw) {
+        rewriter.in_node(Kind::ContextLookup, |rewriter| {
+            rewriter.expect(Kind::LookupKw);
+            rewriter.expect(Kind::Ident);
+        });
+        return true;
+    }
+    false
+}
+
+// a helper for expect_ fns
+fn expect(
+    rewriter: &mut ReparseCtx,
+    eat_fn: impl FnOnce(&mut ReparseCtx) -> bool,
+    expected_name: &str,
+) -> bool {
+    if !eat_fn(rewriter) {
+        rewriter.err_and_bump(format!(
+            "expected '{}', found '{}",
+            expected_name,
+            rewriter.nth_kind(0)
+        ));
+        return false;
+    }
+    true
+}
+
+fn at_glyph_or_glyph_class(kind: Kind) -> bool {
+    matches!(
+        kind,
+        Kind::GlyphName | Kind::Cid | Kind::GlyphClass | Kind::NamedGlyphClass
+    )
+}
+
+fn eat_glyph_or_glyph_class(rewriter: &mut ReparseCtx) -> bool {
+    if at_glyph_or_glyph_class(rewriter.nth_kind(0)) {
+        rewriter.eat_any();
+        return true;
+    }
+    false
+}
+
+fn expect_glyph_or_glyph_class(rewriter: &mut ReparseCtx) -> bool {
+    expect(rewriter, eat_glyph_or_glyph_class, "glyph or glyph class")
+}

--- a/fea-rs/src/token_tree/token.rs
+++ b/fea-rs/src/token_tree/token.rs
@@ -154,7 +154,13 @@ pub enum Kind {
     // general purpose table node
     TableEntryNode,
     // node-only tokens, assigned during parsing
+    // a catchall, includes gsub nodes with errors
     GsubNode,
+    // a contextual or chaining contextual rule that needs to be rewritten.
+    // when the sink sees a node finished with this type, it rewrites it before
+    // adding it to the parent.
+    GsubNodeNeedsRewrite,
+
     GsubType1,
     GsubType2,
     GsubType3,
@@ -175,6 +181,14 @@ pub enum Kind {
     GposType7,
     GposType8,
     GposIgnore,
+
+    // context & chaining context rule components:
+    BacktrackSequence,
+    LookaheadSequence,
+    ContextSequence,
+    ContextGlyphNode,
+    ContextLookup,
+    InlineSubNode,
 
     AnchorMarkNode,
     LigatureComponentNode,
@@ -428,6 +442,7 @@ impl std::fmt::Display for Kind {
             Self::ValueRecordNode => write!(f, "ValueRecordNode"),
             Self::ValueRecordDefNode => write!(f, "ValueRecordDefNode"),
             Self::GsubNode => write!(f, "GsubNode"),
+            Self::GsubNodeNeedsRewrite => write!(f, "GsubNodeNeedsRewrite"),
             Self::GsubType1 => write!(f, "GsubType1"),
             Self::GsubType2 => write!(f, "GsubType2"),
             Self::GsubType3 => write!(f, "GsubType3"),
@@ -447,6 +462,14 @@ impl std::fmt::Display for Kind {
             Self::GposType7 => write!(f, "GposType7"),
             Self::GposType8 => write!(f, "GposType8"),
             Self::GposIgnore => write!(f, "GposIgnore"),
+
+            Self::BacktrackSequence => write!(f, "BacktrackSequence"),
+            Self::LookaheadSequence => write!(f, "LookaheadSequence"),
+            Self::ContextSequence => write!(f, "ContextSequence"),
+            Self::ContextGlyphNode => write!(f, "ContextGlyphNode"),
+            Self::ContextLookup => write!(f, "ContextLookup"),
+            Self::InlineSubNode => write!(f, "InlineSubNode"),
+
             Self::LookupRefNode => write!(f, "LookupRefNode"),
             Self::LookupBlockNode => write!(f, "LookupBlockNode"),
             Self::ScriptRecordNode => write!(f, "ScriptRecoordNode"),

--- a/fea-rs/src/token_tree/token.rs
+++ b/fea-rs/src/token_tree/token.rs
@@ -153,7 +153,8 @@ pub enum Kind {
 
     // general purpose table node
     TableEntryNode,
-    // node-only tokens, assigned during parsing
+    // ## node-only tokens, assigned during parsing ##
+
     // a catchall, includes gsub nodes with errors
     GsubNode,
     // a contextual or chaining contextual rule that needs to be rewritten.
@@ -171,7 +172,11 @@ pub enum Kind {
     GsubType8,
     GsubIgnore,
 
+    // catchall, including gpos nodes with errors
     GposNode,
+    // A node containing marked glyphs, and which needs to be rewritten.
+    GposNodeNeedsRewrite,
+
     GposType1,
     GposType2,
     GposType3,
@@ -453,6 +458,7 @@ impl std::fmt::Display for Kind {
             Self::GsubType8 => write!(f, "GsubType8"),
             Self::GsubIgnore => write!(f, "GsubIgnore"),
             Self::GposNode => write!(f, "GposNode"),
+            Self::GposNodeNeedsRewrite => write!(f, "GposNodeNeedsRewrite"),
             Self::GposType1 => write!(f, "GposType1"),
             Self::GposType2 => write!(f, "GposType2"),
             Self::GposType3 => write!(f, "GposType3"),

--- a/fea-rs/src/token_tree/token.rs
+++ b/fea-rs/src/token_tree/token.rs
@@ -194,6 +194,9 @@ pub enum Kind {
     ContextGlyphNode,
     ContextLookup,
     InlineSubNode,
+    // there can be multiple ignore rules specified in the same block, separated
+    // by commas
+    IgnoreRuleStatementNode,
 
     AnchorMarkNode,
     LigatureComponentNode,
@@ -475,6 +478,7 @@ impl std::fmt::Display for Kind {
             Self::ContextGlyphNode => write!(f, "ContextGlyphNode"),
             Self::ContextLookup => write!(f, "ContextLookup"),
             Self::InlineSubNode => write!(f, "InlineSubNode"),
+            Self::IgnoreRuleStatementNode => write!(f, "IgnoreRuleStatementNode"),
 
             Self::LookupRefNode => write!(f, "LookupRefNode"),
             Self::LookupBlockNode => write!(f, "LookupBlockNode"),


### PR DESCRIPTION
This adds the ability to optionally 'rewrite' nodes after the first parsing pass.

This is an opportunity to change the tree structure, but keeping all of the existing tokens. For instance, you might take a node with four children, and replace it with a node containing two children, each containing two of the original nodes.

This additional structure is important for things like contextual rules, so that we can group the input glyphs into backtrack/context/lookahead groups.