### PR TITLE
Compare output of error tests

### DIFF
--- a/fea-rs/src/bin/ttx_test.rs
+++ b/fea-rs/src/bin/ttx_test.rs
@@ -33,7 +33,7 @@ fn save_wip_diffs(results: &ttx::Results) {
             let out_path = Path::new(WIP_DIFF_DIR)
                 .join(&file_name)
                 .with_extension("expected_diff");
-            let diff = ttx::plain_text_diff(&expected, &result);
+            let diff = ttx::plain_text_diff(expected, result);
             eprintln!("saved diff to {}", out_path.display());
             std::fs::write(out_path, diff).unwrap();
         }

--- a/fea-rs/src/tests.rs
+++ b/fea-rs/src/tests.rs
@@ -1,3 +1,5 @@
 mod compile_ttx;
 mod parse;
 mod should_fail;
+
+pub(crate) const WRITE_RESULTS_VAR: &str = "FEA_WRITE_TEST_OUTPUT";

--- a/fea-rs/src/tests/parse.rs
+++ b/fea-rs/src/tests/parse.rs
@@ -6,19 +6,13 @@
 //! To regenerate the comparison files, pass FEA_WRITE_TEST_OUTPUT=1 as an
 //! environment variable.
 
-use std::{
-    env,
-    ffi::OsStr,
-    path::{Path, PathBuf},
-};
+use std::{env, path::PathBuf};
 
 use crate::util::ttx::{self as test_utils, Failure, Reason, Results};
-use crate::{Diagnostic, ParseTree};
 
 static PARSE_GOOD: &str = "./test-data/parse-tests/good";
 static PARSE_BAD: &str = "./test-data/parse-tests/bad";
 static OTHER_TESTS: &[&str] = &["./test-data/include-resolution-tests/dir1/test1.fea"];
-const WRITE_RESULTS_VAR: &str = "FEA_WRITE_TEST_OUTPUT";
 const GOOD_OUTPUT_EXTENSION: &str = "PARSE_TREE";
 const BAD_OUTPUT_EXTENSION: &str = "ERR";
 
@@ -30,7 +24,7 @@ fn parse_good() -> Result<(), Results> {
         env::current_dir()
     );
 
-    let results = iter_fea_files(PARSE_GOOD)
+    let results = test_utils::iter_fea_files(PARSE_GOOD)
         .chain(OTHER_TESTS.iter().map(PathBuf::from))
         .map(run_good_test)
         .collect::<Vec<_>>();
@@ -39,30 +33,24 @@ fn parse_good() -> Result<(), Results> {
 
 #[test]
 fn parse_bad() -> Result<(), Results> {
-    test_utils::finalize_results(iter_fea_files(PARSE_BAD).map(run_bad_test).collect())
-}
-
-fn iter_fea_files(path: impl AsRef<Path>) -> impl Iterator<Item = PathBuf> {
-    let mut dir = path.as_ref().read_dir().unwrap();
-    std::iter::from_fn(move || loop {
-        let entry = dir.next()?.unwrap();
-        let path = entry.path();
-        if path.extension() == Some(OsStr::new("fea")) {
-            return Some(path);
-        }
-    })
+    test_utils::finalize_results(
+        test_utils::iter_fea_files(PARSE_BAD)
+            .map(run_bad_test)
+            .collect(),
+    )
 }
 
 fn run_good_test(path: PathBuf) -> Result<PathBuf, Failure> {
-    match std::panic::catch_unwind(|| match try_parse_file(&path) {
+    match std::panic::catch_unwind(|| match test_utils::try_parse_file(&path, None) {
         Err((node, errs)) => Err(Failure {
             path: path.clone(),
             reason: Reason::ParseFail(test_utils::stringify_diagnostics(&node, &errs)),
         }),
         Ok(node) => {
             let output = node.root().simple_parse_tree();
-            let result = compare_to_expected_output(&output, &path, GOOD_OUTPUT_EXTENSION);
-            if result.is_err() && std::env::var(WRITE_RESULTS_VAR).is_ok() {
+            let result =
+                test_utils::compare_to_expected_output(&output, &path, GOOD_OUTPUT_EXTENSION);
+            if result.is_err() && std::env::var(super::WRITE_RESULTS_VAR).is_ok() {
                 let to_write = node.root().simple_parse_tree();
                 let to_path = path.with_extension(GOOD_OUTPUT_EXTENSION);
                 std::fs::write(&to_path, &to_write).expect("failed to write output");
@@ -80,11 +68,11 @@ fn run_good_test(path: PathBuf) -> Result<PathBuf, Failure> {
 }
 
 fn run_bad_test(path: PathBuf) -> Result<PathBuf, Failure> {
-    match std::panic::catch_unwind(|| match try_parse_file(&path) {
+    match std::panic::catch_unwind(|| match test_utils::try_parse_file(&path, None) {
         Err((node, errs)) => {
             let msg = test_utils::stringify_diagnostics(&node, &errs);
-            let result = compare_to_expected_output(&msg, &path, BAD_OUTPUT_EXTENSION);
-            if result.is_err() && std::env::var(WRITE_RESULTS_VAR).is_ok() {
+            let result = test_utils::compare_to_expected_output(&msg, &path, BAD_OUTPUT_EXTENSION);
+            if result.is_err() && std::env::var(super::WRITE_RESULTS_VAR).is_ok() {
                 let to_path = path.with_extension(BAD_OUTPUT_EXTENSION);
                 std::fs::write(&to_path, &msg).expect("failed to write output");
             }
@@ -102,37 +90,4 @@ fn run_bad_test(path: PathBuf) -> Result<PathBuf, Failure> {
         Ok(Err(e)) => Err(e),
         Ok(_) => Ok(path),
     }
-}
-
-/// returns the tree and any errors
-fn try_parse_file(path: &Path) -> Result<ParseTree, (ParseTree, Vec<Diagnostic>)> {
-    let ctx = crate::parse_root_file(path, None, None).unwrap();
-    let (tree, errors) = ctx.generate_parse_tree();
-    if errors.iter().any(Diagnostic::is_error) {
-        Err((tree, errors))
-    } else {
-        Ok(tree)
-    }
-}
-
-fn compare_to_expected_output(output: &str, src_path: &Path, cmp_ext: &str) -> Result<(), Failure> {
-    let cmp_path = src_path.with_extension(cmp_ext);
-    let expected = if cmp_path.exists() {
-        std::fs::read_to_string(&cmp_path).expect("failed to read cmp_path")
-    } else {
-        String::new()
-    };
-
-    if expected != output {
-        let diff_percent = test_utils::compute_diff_percentage(&expected, output);
-        return Err(Failure {
-            path: src_path.to_owned(),
-            reason: Reason::CompareFail {
-                expected,
-                result: output.to_string(),
-                diff_percent,
-            },
-        });
-    }
-    Ok(())
 }

--- a/fea-rs/src/tests/should_fail.rs
+++ b/fea-rs/src/tests/should_fail.rs
@@ -1,45 +1,56 @@
 //! ensuring that invalid inputs produce useful diagnostics
 
-use std::{
-    ffi::OsStr,
-    path::{Path, PathBuf},
+use std::path::{Path, PathBuf};
+
+use crate::{
+    util::ttx::{self as test_utils, Failure, Reason, Results},
+    GlyphMap,
 };
 
-use crate::util::ttx;
-
 static TEST_DATA: &str = "./test-data/error-tests";
+static OUTPUT_EXTENSION: &str = "ERR";
 
-//TODO: at some point it would be nice to have a fancy test harness like
-// [trybuild](https://github.com/dtolnay/trybuild) that we could check our
-// diagnostics against.
 #[test]
-fn expected_failures() {
-    let glyph_map = ttx::make_glyph_map();
-    let mut failures = Vec::new();
-    for path in iter_compile_tests(TEST_DATA) {
-        let result = ttx::try_compile(&path, &glyph_map);
-        if result.is_ok() {
-            failures.push(path);
-        }
-    }
+fn expected_failures() -> Result<(), Results> {
+    let glyph_map = test_utils::make_glyph_map();
+    test_utils::finalize_results(
+        test_utils::iter_fea_files(TEST_DATA)
+            .map(|path| run_bad_test(path, &glyph_map))
+            .collect(),
+    )
+}
 
-    if !failures.is_empty() {
-        eprintln!("failures ({}):", failures.len());
-        for path in &failures {
-            eprintln!("  {}", path.display());
-        }
-        eprintln!();
-        panic!("ahhh");
+fn run_bad_test(path: PathBuf, map: &GlyphMap) -> Result<PathBuf, Failure> {
+    match std::panic::catch_unwind(|| try_to_compile(&path, map)) {
+        Err(_) => Err(Failure {
+            path,
+            reason: Reason::Panic,
+        }),
+        Ok(Err(e)) => Err(e),
+        Ok(_) => Ok(path),
     }
 }
 
-fn iter_compile_tests(path: impl AsRef<Path>) -> impl Iterator<Item = PathBuf> + 'static {
-    let mut dir = path.as_ref().read_dir().unwrap();
-    std::iter::from_fn(move || loop {
-        let entry = dir.next()?.unwrap();
-        let path = entry.path();
-        if path.extension() == Some(OsStr::new("fea")) {
-            return Some(path);
-        }
-    })
+fn try_to_compile(path: &Path, glyph_map: &GlyphMap) -> Result<(), Failure> {
+    match test_utils::try_parse_file(path, Some(glyph_map)) {
+        Err((node, errs)) => Err(Failure {
+            path: path.to_owned(),
+            reason: Reason::ParseFail(test_utils::stringify_diagnostics(&node, &errs)),
+        }),
+        Ok(node) => match crate::compile(&node, glyph_map) {
+            Ok(_) => Err(Failure {
+                path: path.to_owned(),
+                reason: Reason::CompileFail("unexpected success".into()),
+            }),
+            Err(errs) => {
+                let msg = test_utils::stringify_diagnostics(&node, &errs);
+                let result = test_utils::compare_to_expected_output(&msg, path, OUTPUT_EXTENSION);
+                if result.is_err() && std::env::var(super::WRITE_RESULTS_VAR).is_ok() {
+                    let to_path = path.with_extension(OUTPUT_EXTENSION);
+                    std::fs::write(&to_path, &msg).expect("failed to write output");
+                }
+                result
+            }
+        },
+    }
 }


### PR DESCRIPTION
This includes some fixes to the error output when we validate the size
table, because that was being handled incorrectly.

This includes some refactoring so that more of the "compare this output
to that output" tests can share code.