### PR TITLE
Compile contextual rules

### DIFF
--- a/fea-rs/src/compile/lookups.rs
+++ b/fea-rs/src/compile/lookups.rs
@@ -419,6 +419,29 @@ impl SomeLookup {
         }
     }
 
+    pub(crate) fn add_gpos_type_8(
+        &mut self,
+        backtrack: Vec<BTreeSet<u16>>,
+        input: Vec<(BTreeSet<u16>, Vec<u16>)>,
+        lookahead: Vec<BTreeSet<u16>>,
+    ) {
+        if let SomeLookup::GposLookup(Lookup {
+            rule: Positioning::ChainedContextual(table),
+            ..
+        }) = self
+        {
+            let mut subtable = ChainedSequenceContext::default();
+            subtable.rules.push(ChainedSequenceContextRule {
+                backtrack,
+                input,
+                lookahead,
+            });
+            table.push(subtable);
+        } else {
+            panic!("looup mismatch");
+        }
+    }
+
     pub(crate) fn add_gsub_type_1(&mut self, id: GlyphId, replacement: GlyphId) {
         if let SomeLookup::GsubLookup(Lookup {
             rule: Substitution::Single(table),

--- a/fea-rs/src/compile/validate.rs
+++ b/fea-rs/src/compile/validate.rs
@@ -756,13 +756,11 @@ impl<'a> ValidationCtx<'a> {
                 let input_seq = rule.input();
                 for (i, item) in input_seq.items().enumerate() {
                     let target = item.target();
-                    if i == 0 && inline_class_sub {
-                        if !target.is_class() {
-                            self.error(
+                    if i == 0 && inline_class_sub && !target.is_class() {
+                        self.error(
                             input_seq.range(),
                             "if replacing by glyph class, input sequence must be a single glyph class",
                         );
-                        }
                     }
                     self.validate_glyph_or_class(&item.target());
                     for lookup in item.lookups() {

--- a/fea-rs/src/token_tree/token.rs
+++ b/fea-rs/src/token_tree/token.rs
@@ -259,29 +259,6 @@ pub enum Kind {
 }
 
 impl Kind {
-    // only used for debugging
-    pub(crate) fn has_contents(&self) -> bool {
-        matches!(
-            self,
-            Self::Ident
-                | Self::String
-                | Self::StringUnterminated
-                | Self::Float
-                | Self::Hex
-                | Self::HexEmpty
-                | Self::Octal
-                | Self::Comment
-                | Self::Whitespace
-                | Self::NamedGlyphClass
-                | Self::GlyphName
-                | Self::Metric
-                | Self::Number
-                | Self::Label
-                | Self::Cid
-                | Self::Tag
-        )
-    }
-
     pub(crate) fn is_rule(&self) -> bool {
         matches!(
             self,

--- a/fea-rs/src/token_tree/typed.rs
+++ b/fea-rs/src/token_tree/typed.rs
@@ -880,6 +880,7 @@ impl Gpos6 {
     }
 }
 
+//FIXME: move backtrack/lookahead/input into a trait
 impl Gpos8 {
     pub fn backtrack(&self) -> BacktrackSequence {
         self.iter().find_map(BacktrackSequence::cast).unwrap()

--- a/fea-rs/src/token_tree/typed.rs
+++ b/fea-rs/src/token_tree/typed.rs
@@ -774,6 +774,11 @@ impl InlineSubRule {
     pub fn replacement_glyphs(&self) -> impl Iterator<Item = Glyph> + '_ {
         self.iter().filter_map(Glyph::cast)
     }
+
+    // this overlaps with the other two? i don't know what the best API is.. :/
+    pub fn replacements(&self) -> impl Iterator<Item = GlyphOrClass> + '_ {
+        self.iter().filter_map(GlyphOrClass::cast)
+    }
 }
 
 impl Gpos1 {

--- a/fea-rs/src/util.rs
+++ b/fea-rs/src/util.rs
@@ -14,3 +14,32 @@ pub use pretty_diff::write_line_diff;
 
 #[doc(hidden)]
 pub static SPACES: &str = "                                                                                                                                                                                    ";
+
+// just used for sanity checking
+pub(crate) fn is_sorted<T: PartialOrd>(slice: &[T]) -> bool {
+    if slice.len() > 2 {
+        let mut prev = &slice[0];
+        for item in &slice[1..] {
+            if prev > item {
+                return false;
+            }
+            prev = item;
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_sorted_() {
+        assert!(is_sorted::<u32>(&[]));
+        assert!(is_sorted(&[1]));
+        assert!(is_sorted(&[1, 1, 1]));
+        assert!(is_sorted(&[1, 2, 11, 11, 12]));
+        assert!(!is_sorted(&[3, 2, 11, 11, 12]));
+        assert!(!is_sorted(&[2, 11, 11, 12, 11]));
+    }
+}


### PR DESCRIPTION
This adds compilation of GSUB 5,6, and 8, and GPOS 7 & 8, including `ignore` statements.

This only generates chaining contextual lookups, even when there are no backtrack/lookahead items, and it has a number of other little quirks, but it's a reasonable starting point.