### PR TITLE
GDEF inference & tweaks

### DIFF
--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -1327,7 +1327,10 @@ impl<'a> CompilationCtx<'a> {
                         .collect::<Vec<_>>();
                     assert!(!indices.is_empty(), "check this in validation");
                     for glyph in glyphs.iter() {
-                        gdef.attach.push((glyph, indices.clone()));
+                        gdef.attach
+                            .entry(glyph)
+                            .or_default()
+                            .extend(indices.iter().copied());
                     }
                 }
                 typed::GdefTableItem::LigatureCaret(rule) => {

--- a/fea-rs/src/compile/tables.rs
+++ b/fea-rs/src/compile/tables.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 use fonttools::{
     tables::GDEF::{CaretValue, GlyphClass as FtGlyphClass},
@@ -80,8 +80,8 @@ pub struct GDEF {
     pub mark_glyphs: Option<GlyphClass>,
     pub component_glyphs: Option<GlyphClass>,
 
-    pub attach: Vec<(GlyphId, Vec<u16>)>,
-    pub ligature_caret_pos: HashMap<GlyphId, Vec<i16>>,
+    pub attach: HashMap<GlyphId, BTreeSet<u16>>,
+    pub ligature_caret_pos: HashMap<GlyphId, BTreeSet<i16>>,
     pub ligature_caret_index: HashMap<GlyphId, Vec<u16>>,
 }
 
@@ -376,13 +376,11 @@ impl GDEF {
                 .insert(id.to_raw(), FtGlyphClass::ComponentGlyph);
         }
 
-        //TODO: turn this back on when supported in fonttools
-        // (https://github.com/simoncozens/fonttools-rs/issues/59)
-        //for (glyph, points) in &self.attach {
-        //table
-        //.attachment_point_list
-        //.insert(glyph.to_raw(), points.clone());
-        //}
+        for (glyph, points) in &self.attach {
+            table
+                .attachment_point_list
+                .insert(glyph.to_raw(), points.iter().copied().collect());
+        }
 
         for (glyph, points) in &self.ligature_caret_index {
             let points = points

--- a/fea-rs/src/types.rs
+++ b/fea-rs/src/types.rs
@@ -45,7 +45,6 @@ impl GlyphId {
         self.0
     }
 
-    #[cfg(test)]
     pub fn from_raw(raw: u16) -> Self {
         Self(raw)
     }


### PR DESCRIPTION
If a GDEF table is not specified, we will infer glyph classes from defined mark classes and rules.

This also includes a few other tweaks related to GDEF:
- ignore `LigatureCaret` statements for any glyph that has a previous statement
- sort `LigatureCaret` values (which matches output from afdko & fonttools)
- handle GDEF `Attach` statements 