### PR TITLE
Compile with only FEA and a glyph ordering

### DIFF
--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["parsing", "text-processing"]
 keywords = ["fonts", "opentype"]
 readme = "README.md"
 edition = "2018"
-default-run = "parse_test"
+default-run = "fea-rs"
 exclude = ["test-data"]
 
 [dependencies]
@@ -24,6 +24,7 @@ diff = { version = "0.1.12", optional = true }
 rayon = { version = "1.5", optional = true }
 serde = { version = "1.0.147", features = ["derive"], optional = true }
 serde_json = {version = "1.0.87", optional = true }
+thiserror = "1.0.37"
 
 [features]
 test = ["diff", "rayon", "serde", "serde_json"]

--- a/fea-rs/src/bin/compile.rs
+++ b/fea-rs/src/bin/compile.rs
@@ -1,34 +1,21 @@
 //! Compile features into a font file
 
+use std::path::Path;
+
 use fea_rs::{GlyphMap, GlyphName};
-use write_fonts::{
-    read::{tables::post::Post, FontData, FontRef, TableProvider},
-    types::GlyphId,
-};
+use write_fonts::{read::tables::post::Post, types::GlyphId};
 
 /// Attempt to compile features into a font file.
 ///
 /// usage: FONT_PATH FEA_PATH
-fn main() {
-    let args = match flags::Args::from_env() {
-        Ok(args) if args.help => {
-            println!("{}", flags::Args::HELP);
-            return;
-        }
-        Ok(args) => args,
-        Err(err) => {
-            eprintln!("Error: {}.\n\nUsage:\n{}", err, flags::Args::HELP);
-            std::process::exit(1);
-        }
-    };
+fn main() -> Result<(), Error> {
+    let args = flags::Args::from_env()?;
+    if args.help {
+        println!("{}", flags::Args::HELP);
+        return Ok(());
+    }
 
-    let bytes = std::fs::read(args.path()).expect("failed to load font data");
-    let data = FontData::new(&bytes);
-    let font = FontRef::new(data).expect("failed to parse font");
-    let post = font.post().expect("failed to read 'post' table");
-    let names = try_to_make_glyph_map(post)
-        .expect("no glyph names in post table, which is currently required");
-
+    let names = parse_glyph_order(args.glyph_order())?;
     let parse = fea_rs::parse_root_file(args.fea(), Some(&names), None).unwrap();
     let (tree, diagnostics) = parse.generate_parse_tree();
     let mut has_error = false;
@@ -40,12 +27,12 @@ fn main() {
         std::process::exit(1);
     }
 
-    match fea_rs::compile(&tree, &names) {
+    let compiled = match fea_rs::compile(&tree, &names) {
         Ok(compilation) => {
-            compilation.apply(&font).unwrap();
             for warning in &compilation.warnings {
                 eprintln!("{}", tree.format_diagnostic(warning));
             }
+            compilation
         }
 
         Err(errors) => {
@@ -60,47 +47,37 @@ fn main() {
             println!("{} errors, {} warnings", err_count, warning_count);
             std::process::exit(1);
         }
-    }
+    };
 
-    //match &args.subcommand {
-    //flags::ArgsCmd::Compile(args) => {
-    //if let Some(path) = &args.out_path {
-    //font.save(path).unwrap()
-    //} else {
-    //font.save("compile-out.ttf").unwrap()
-    //}
-    //}
-    //flags::ArgsCmd::Debug(args) => {
-    //let to_print = args
-    //.print_tables
-    //.as_ref()
-    //.map(|s| s.split(',').map(|s| s.to_owned()).collect::<HashSet<_>>())
-    //.unwrap_or_default();
-    //if to_print.is_empty() {
-    //fea_rs::util::debug::explode_font(&font, args.verbose);
-    //}
-
-    //for table in to_print {
-    //if table == "GPOS" {
-    //if let Some(gpos) = font.tables.GPOS().unwrap() {
-    //util::debug::explode_gpos(&gpos, args.verbose);
-    //} else {
-    //eprintln!("no GPOS table exists");
-    //}
-    //} else if table == "GSUB" {
-    //if let Some(gsub) = font.tables.GSUB().unwrap() {
-    //util::debug::explode_gsub(&gsub, args.verbose);
-    //} else {
-    //eprintln!("no GSUB table exists");
-    //}
-    //} else {
-    //eprintln!("unknown table '{}'", table);
-    //}
-    //}
-    //}
-    //}
+    let path = args.out_path();
+    let raw_font = compiled.build_raw(&names).expect("ttf compile failed");
+    std::fs::write(path, raw_font).map_err(Into::into)
 }
 
+fn parse_glyph_order(path: &Path) -> Result<GlyphMap, Error> {
+    let contents = std::fs::read_to_string(path)?;
+    let map: GlyphMap = contents
+        .lines()
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .map(|line| {
+            if line.bytes().any(|b| b.is_ascii_whitespace()) {
+                Err(Error::InvalidGlyphMap(format!(
+                    "name {line:?} contains whitespace"
+                )))
+            } else {
+                Ok(GlyphName::new(line))
+            }
+        })
+        .collect::<Result<_, _>>()?;
+    if map.get(".notdef") != Some(GlyphId::NOTDEF) {
+        Err(Error::InvalidGlyphMap("first glyph must be .notdef".into()))
+    } else {
+        Ok(map)
+    }
+}
+
+//FIXME: if we support having a font as input, again?
+#[allow(dead_code)]
 fn try_to_make_glyph_map(post: Post) -> Option<GlyphMap> {
     let Some(num_glyphs) = post.num_glyphs() else {
         return None;
@@ -115,47 +92,50 @@ fn try_to_make_glyph_map(post: Post) -> Option<GlyphMap> {
     )
 }
 
+#[derive(Debug, thiserror::Error)]
+enum Error {
+    #[error("bad args, pass -h for help '{0}'")]
+    Arguments(#[from] xflags::Error),
+    #[error("invalid glyph map: '{0}'")]
+    InvalidGlyphMap(String),
+    #[error("io error: '{0}'")]
+    File(#[from] std::io::Error),
+}
+
 mod flags {
     use std::path::{Path, PathBuf};
     xflags::xflags! {
 
         /// Compile a fea file into a source font
-        cmd args {
-            cmd compile
-                /// Path to the font
-                required path: PathBuf
-                /// Path to the fea file
-                required fea: PathBuf
-                {
-                    optional -o, --out-path out_path: PathBuf
-                }
-            cmd debug
-                /// Path to test FEA file. This should be in a directory that
-                /// contains a 'font.ttf' file to be used for testing.
-                /// Comma-separated list of tables to print (e.g: -p GSUB,GPOS)
-                required fea: PathBuf
-                {
-                    optional -p, --print-tables tables: String
-                    optional -v, --verbose
-                }
-            /// Print help
-            optional -h, --help
-        }
+        cmd args
+            /// Path to the fea file
+            required fea: PathBuf
+            /// Path to a file containing the glyph order.
+            ///
+            /// This should be a utf-8 encoded file with one name per line,
+            /// sorted in glyphid order.
+            required glyphs: PathBuf
+            {
+                /// path to write font. Defaults to 'compile-out.ttf'
+                optional -o, --out-path out_path: PathBuf
+                /// Print help
+                optional -h, --help
+            }
     }
 
     impl Args {
         pub fn fea(&self) -> &Path {
-            match &self.subcommand {
-                ArgsCmd::Compile(args) => &args.fea,
-                ArgsCmd::Debug(args) => &args.fea,
-            }
+            &self.fea
         }
 
-        pub fn path(&self) -> PathBuf {
-            match &self.subcommand {
-                ArgsCmd::Compile(args) => args.path.clone(),
-                ArgsCmd::Debug(args) => args.fea.with_file_name("font.ttf"),
-            }
+        pub fn glyph_order(&self) -> &Path {
+            &self.glyphs
+        }
+
+        pub fn out_path(&self) -> &Path {
+            self.out_path
+                .as_deref()
+                .unwrap_or_else(|| Path::new("compile-out.ttf"))
         }
     }
 }

--- a/fea-rs/src/bin/compile.rs
+++ b/fea-rs/src/bin/compile.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 
 use fea_rs::{GlyphMap, GlyphName};
-use write_fonts::{read::tables::post::Post, types::GlyphId};
+use write_fonts::types::GlyphId;
 
 /// Attempt to compile features into a font file.
 ///
@@ -76,22 +76,6 @@ fn parse_glyph_order(path: &Path) -> Result<GlyphMap, Error> {
     }
 }
 
-//FIXME: if we support having a font as input, again?
-#[allow(dead_code)]
-fn try_to_make_glyph_map(post: Post) -> Option<GlyphMap> {
-    let Some(num_glyphs) = post.num_glyphs() else {
-        return None;
-    };
-
-    Some(
-        (0..num_glyphs)
-            .map(GlyphId::new)
-            .map(|id| post.glyph_name(id).unwrap())
-            .map(GlyphName::new)
-            .collect(),
-    )
-}
-
 #[derive(Debug, thiserror::Error)]
 enum Error {
     #[error("bad args, pass -h for help '{0}'")]
@@ -137,5 +121,19 @@ mod flags {
                 .as_deref()
                 .unwrap_or_else(|| Path::new("compile-out.ttf"))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_glyph_map() {
+        let glyph_map = parse_glyph_order(Path::new("./test-data/simple_glyph_order.txt")).unwrap();
+        assert_eq!(glyph_map.len(), 215);
+        assert_eq!(glyph_map.get("space"), Some(GlyphId::new(1)));
+        assert_eq!(glyph_map.get("e.fina"), Some(GlyphId::new(214)));
+        assert!(!glyph_map.contains("e.nada"));
     }
 }

--- a/fea-rs/src/util/ttx.rs
+++ b/fea-rs/src/util/ttx.rs
@@ -2,7 +2,6 @@
 
 use std::{
     collections::HashMap,
-    convert::TryInto,
     env::temp_dir,
     ffi::OsStr,
     fmt::{Debug, Display, Write},
@@ -11,18 +10,11 @@ use std::{
     time::SystemTime,
 };
 
-use crate::{Compilation, Diagnostic, GlyphIdent, GlyphMap, GlyphName, ParseTree};
+use crate::{Diagnostic, GlyphIdent, GlyphMap, GlyphName, ParseTree};
 
 use ansi_term::Color;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
-
-use write_fonts::{
-    read::{FontData, FontRef},
-    tables::maxp::Maxp,
-    types::Tag,
-    FontBuilder,
-};
 
 static IGNORED_TESTS: &[&str] = &[
     // ## tests with invalid syntax ## //
@@ -227,7 +219,7 @@ fn run_test(
                 reason: TestResult::CompileFail(stringify_diagnostics(&node, &errs)),
             }),
             Ok(result) => {
-                let font_data = build_font(result, glyph_map);
+                let font_data = result.build_raw(glyph_map).unwrap();
                 compare_ttx(&font_data, &path, reverse_map)
             }
         },
@@ -242,19 +234,6 @@ fn run_test(
         Ok(Ok(_)) => (),
     };
     Ok(path)
-}
-
-fn build_font(compilation: Compilation, glyphs: &GlyphMap) -> Vec<u8> {
-    let empty = make_empty_font(glyphs.len());
-    let font = FontRef::new(FontData::new(&empty)).unwrap();
-    compilation.apply(&font).unwrap()
-}
-
-fn make_empty_font(n_glyphs: usize) -> Vec<u8> {
-    let mut font = FontBuilder::default();
-    let maxp = Maxp::new(n_glyphs.try_into().unwrap());
-    font.add_table(Tag::new(b"maxp"), write_fonts::dump_table(&maxp).unwrap());
-    font.build()
 }
 
 pub fn stringify_diagnostics(root: &ParseTree, diagnostics: &[Diagnostic]) -> String {


### PR DESCRIPTION
This updates the main binary to work with only a FEA file and a glyph ordering.

A glyph ordering is a text file with one glyph name per line. Lines preceded by '#' are ignored.

This is very bare bones, but should get us to a place where this can be used to compile tables.