### PR TITLE
Cleanup for 0.0.1 release

### DIFF
--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fea-rs"
-version = "0.0.0"
+version = "0.0.1"
 license = "Apache-2.0"
 authors = ["Colin Rofls <colin@cmyr.net>"]
 description = "Tools for working with Adobe OpenType Feature files."
@@ -15,10 +15,9 @@ exclude = ["test-data"]
 [dependencies]
 ansi_term = "0.12.1"
 smol_str = "0.1.18"
-norad = "0.5" # just for use in sample binaries/debugging, remove eventually
-write-fonts = { git = "https://github.com/googlefonts/fontations", rev = "cff792e"}
-#write-fonts = { version = "0.0.3", path = "../../fontations/write-fonts" }
-xflags = "0.2.3"
+norad = "0.7" # just for use in sample binaries/debugging, remove eventually
+write-fonts = "0.0.4"
+xflags = "0.3.1"
 chrono = "0.4.3"
 diff = { version = "0.1.12", optional = true }
 rayon = { version = "1.5", optional = true }
@@ -32,7 +31,7 @@ test = ["diff", "rayon", "serde", "serde_json"]
 [dev-dependencies]
 diff = "0.1.12"
 rayon = "1.5"
-criterion = "0.3"
+criterion = "0.4"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.87"
 

--- a/fea-rs/src/bin/compile.rs
+++ b/fea-rs/src/bin/compile.rs
@@ -9,11 +9,10 @@ use write_fonts::types::GlyphId;
 ///
 /// usage: FONT_PATH FEA_PATH
 fn main() -> Result<(), Error> {
-    let args = flags::Args::from_env()?;
-    if args.help {
-        println!("{}", flags::Args::HELP);
-        return Ok(());
-    }
+    let args = match flags::Args::from_env() {
+        Ok(args) => args,
+        Err(e) => e.exit(),
+    };
 
     let names = parse_glyph_order(args.glyph_order())?;
     let parse = fea_rs::parse_root_file(args.fea(), Some(&names), None).unwrap();
@@ -78,8 +77,6 @@ fn parse_glyph_order(path: &Path) -> Result<GlyphMap, Error> {
 
 #[derive(Debug, thiserror::Error)]
 enum Error {
-    #[error("bad args, pass -h for help '{0}'")]
-    Arguments(#[from] xflags::Error),
     #[error("invalid glyph map: '{0}'")]
     InvalidGlyphMap(String),
     #[error("io error: '{0}'")]
@@ -89,9 +86,8 @@ enum Error {
 mod flags {
     use std::path::{Path, PathBuf};
     xflags::xflags! {
-
         /// Compile a fea file into a source font
-        cmd args
+        cmd args {
             /// Path to the fea file
             required fea: PathBuf
             /// Path to a file containing the glyph order.
@@ -99,11 +95,9 @@ mod flags {
             /// This should be a utf-8 encoded file with one name per line,
             /// sorted in glyphid order.
             required glyphs: PathBuf
-            {
+
                 /// path to write font. Defaults to 'compile-out.ttf'
                 optional -o, --out-path out_path: PathBuf
-                /// Print help
-                optional -h, --help
             }
     }
 

--- a/fea-rs/src/compile/output.rs
+++ b/fea-rs/src/compile/output.rs
@@ -7,7 +7,7 @@ use std::{
 
 use write_fonts::{
     dump_table,
-    read::{FontData, FontRef, TableProvider},
+    read::{FontRef, TableProvider},
     tables::{
         layout::{FeatureParams, SizeParams, StylisticSetParams},
         maxp::Maxp,
@@ -53,7 +53,7 @@ impl Compilation {
         let maxp = Maxp::new(glyph_map.len().try_into().unwrap());
         builder.add_table(Tag::new(b"maxp"), write_fonts::dump_table(&maxp).unwrap());
         let empty = builder.build();
-        let font = FontRef::new(FontData::new(&empty)).unwrap();
+        let font = FontRef::new(&empty).unwrap();
         self.apply(&font)
     }
 

--- a/fea-rs/src/tests/compile.rs
+++ b/fea-rs/src/tests/compile.rs
@@ -2,11 +2,9 @@
 
 use std::path::{Path, PathBuf};
 
-//use fonttools::font::Font;
-
 use write_fonts::{
     from_obj::ToOwnedTable,
-    read::{tables::post::DEFAULT_GLYPH_NAMES, FontData, FontRef, TableProvider},
+    read::{tables::post::DEFAULT_GLYPH_NAMES, FontRef, TableProvider},
     tables::post::Post,
 };
 
@@ -136,7 +134,6 @@ fn good_test_body(path: &Path, glyph_map: &GlyphMap) -> Result<(), TestCase> {
 }
 
 fn make_glyph_map(font_data: &[u8]) -> GlyphMap {
-    let font_data = FontData::new(font_data);
     let font = FontRef::new(font_data).unwrap();
     let post: Post = font.post().unwrap().to_owned_table();
     post.glyph_name_index


### PR DESCRIPTION
- bump version
- update deps (and adjust to new API, in the case of xflags)
- pin to crates.io version of fontations