### PR TITLE
More consistent table builder names

### DIFF
--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -122,7 +122,7 @@ impl<'a> CompilationCtx<'a> {
         if self.errors.iter().any(Diagnostic::is_error) {
             return Err(self.errors.clone());
         }
-        if self.tables.GDEF.is_none() {
+        if self.tables.gdef.is_none() {
             self.infer_glyph_classes();
         }
         Ok(Compilation {
@@ -137,7 +137,7 @@ impl<'a> CompilationCtx<'a> {
     // if a GDEF table is not explicitly defined, we are supposed to create one:
     // http://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#4f-markclass
     fn infer_glyph_classes(&mut self) {
-        let mut gdef = super::tables::Gdef::default();
+        let mut gdef = super::tables::GdefBuilder::default();
         self.lookups.infer_glyph_classes(|glyph, class_id| {
             gdef.glyph_classes.insert(glyph, class_id);
         });
@@ -150,7 +150,7 @@ impl<'a> CompilationCtx<'a> {
             gdef.glyph_classes.insert(glyph, ClassId::Mark);
         }
         if !gdef.glyph_classes.is_empty() {
-            self.tables.GDEF = Some(gdef);
+            self.tables.gdef = Some(gdef);
         }
     }
 
@@ -1180,7 +1180,7 @@ impl<'a> CompilationCtx<'a> {
                 }
             }
         }
-        self.tables.OS2 = Some(os2);
+        self.tables.os2 = Some(os2);
     }
 
     fn resolve_stat(&mut self, table: &typed::StatTable) {
@@ -1310,7 +1310,7 @@ impl<'a> CompilationCtx<'a> {
     }
 
     fn resolve_vmtx(&mut self, table: &typed::VmtxTable) {
-        let mut vmtx = super::tables::vmtx::default();
+        let mut vmtx = super::tables::VmtxBuilder::default();
         for item in table.statements() {
             let glyph = self.resolve_glyph(&item.glyph());
             let value = item.value().parse_signed();
@@ -1324,7 +1324,7 @@ impl<'a> CompilationCtx<'a> {
     }
 
     fn resolve_gdef(&mut self, table: &typed::GdefTable) {
-        let mut gdef = super::tables::Gdef::default();
+        let mut gdef = super::tables::GdefBuilder::default();
         for statement in table.statements() {
             match statement {
                 typed::GdefTableItem::Attach(rule) => {
@@ -1382,11 +1382,11 @@ impl<'a> CompilationCtx<'a> {
                 }
             }
         }
-        self.tables.GDEF = Some(gdef);
+        self.tables.gdef = Some(gdef);
     }
 
     fn resolve_head(&mut self, table: &typed::HeadTable) {
-        let mut head = super::tables::head::default();
+        let mut head = super::tables::HeadBuilder::default();
         let font_rev = table.statements().last().unwrap().value();
         head.font_revision = font_rev.parse_fixed();
         self.tables.head = Some(head);

--- a/fea-rs/src/compile/output.rs
+++ b/fea-rs/src/compile/output.rs
@@ -75,7 +75,7 @@ impl Compilation {
         //font.add_table(Tag::new(b"hhea"), data);
         //}
 
-        if let Some(gdef) = &self.tables.GDEF {
+        if let Some(gdef) = &self.tables.gdef {
             builder.add_table(Tag::new(b"GDEF"), gdef.build().unwrap());
         }
 

--- a/fea-rs/src/compile/tables.rs
+++ b/fea-rs/src/compile/tables.rs
@@ -23,30 +23,28 @@ use crate::{
 };
 
 /// The explicit tables allowed in a fea file
-#[allow(non_snake_case)]
 #[derive(Clone, Debug, Default)]
 pub(crate) struct Tables {
-    pub head: Option<head>,
+    pub head: Option<HeadBuilder>,
     pub hhea: Option<tables::hhea::Hhea>,
     pub vhea: Option<tables::vhea::Vhea>,
-    pub vmtx: Option<vmtx>,
+    pub vmtx: Option<VmtxBuilder>,
     pub name: NameBuilder,
     pub stylistic_sets: HashMap<Tag, Vec<NameSpec>>,
     pub character_variants: HashMap<Tag, CvParams>,
-    pub GDEF: Option<Gdef>,
+    pub gdef: Option<GdefBuilder>,
     pub base: Option<Base>,
-    pub OS2: Option<OS2>,
+    pub os2: Option<OS2>,
     pub stat: Option<StatBuilder>,
 }
 #[derive(Clone, Debug, Default)]
 #[allow(non_camel_case_types)]
-pub struct head {
+pub struct HeadBuilder {
     pub font_revision: Fixed,
 }
 
 #[derive(Clone, Debug, Default)]
-#[allow(non_camel_case_types)]
-pub struct vmtx {
+pub struct VmtxBuilder {
     pub origins_y: Vec<(GlyphId, i16)>,
     pub advances_y: Vec<(GlyphId, i16)>,
 }
@@ -89,7 +87,7 @@ impl From<ClassId> for GlyphClassDef {
 }
 
 #[derive(Clone, Debug, Default)]
-pub struct Gdef {
+pub struct GdefBuilder {
     pub glyph_classes: HashMap<GlyphId, ClassId>,
     pub attach: BTreeMap<GlyphId, BTreeSet<u16>>,
     pub ligature_pos: BTreeMap<GlyphId, Vec<CaretValue>>,
@@ -477,7 +475,7 @@ fn parse_mac(s: &str) -> String {
 // this is the value used in python fonttools when writing this table
 const DATE_2011_12_13_H11_M22_S33: LongDateTime = LongDateTime::new(1323780153);
 
-impl head {
+impl HeadBuilder {
     pub(crate) fn build(&self, font: Option<&FontRef>) -> write_fonts::tables::head::Head {
         // match what python fonttools does
         let mut head = font
@@ -572,7 +570,7 @@ impl OS2 {
     //}
 }
 
-impl Gdef {
+impl GdefBuilder {
     pub fn build(&self) -> Result<Vec<u8>, ValidationReport> {
         let table = tables::gdef::Gdef::new(
             self.build_class_def(),


### PR DESCRIPTION
e.g. they're all suffixed with 'Builder', and I'm also cleaning up some of the old non-rustic names and removing associated `#[allow]` annotations.