### PR TITLE
Do not ignore name ids 1-6

### DIFF
--- a/fea-rs/src/compile/tables.rs
+++ b/fea-rs/src/compile/tables.rs
@@ -337,10 +337,8 @@ impl Default for NameBuilder {
 
 impl NameBuilder {
     pub(crate) fn add(&mut self, name_id: u16, name_spec: NameSpec) {
-        if !(1..=6).contains(&name_id) {
-            self.last_anon_id = self.last_anon_id.max(name_id);
-            self.records.push((name_id, name_spec));
-        }
+        self.last_anon_id = self.last_anon_id.max(name_id);
+        self.records.push((name_id, name_spec));
     }
 
     pub(crate) fn add_anon_group(&mut self, entries: &[NameSpec]) -> u16 {

--- a/fea-rs/src/compile/validate.rs
+++ b/fea-rs/src/compile/validate.rs
@@ -327,12 +327,8 @@ impl<'a> ValidationCtx<'a> {
     fn validate_name(&mut self, node: &typed::NameTable) {
         for record in node.statements() {
             let name_id = record.name_id();
-            match name_id.parse() {
-                Err(e) => self.error(name_id.range(), e),
-                Ok(1..=6) => {
-                    self.warning(name_id.range(), "ID's 1-6 are reserved and will be ignored")
-                }
-                _ => (),
+            if let Err(e) = name_id.parse() {
+                self.error(name_id.range(), e);
             }
             self.validate_name_spec(&record.entry());
         }


### PR DESCRIPTION
The spec says to do this but does not explain why, and fontTools has decided to allow it, so we will match them for now:

see https://github.com/fonttools/fonttools/pull/2675