### PR TITLE
Fixup ligature sub sort order

### DIFF
--- a/fea-rs/src/compile/lookups/gsub.rs
+++ b/fea-rs/src/compile/lookups/gsub.rs
@@ -217,7 +217,12 @@ impl Builder for LigatureSubBuilder {
             .items
             .into_values()
             .map(|mut ligs| {
-                ligs.sort_unstable();
+                ligs.sort_unstable_by(|(lig1, _), (lig2, _)| {
+                    // sort first decending by len, then lexicographically; we want
+                    // longer sequences ahead of shorter ones, while also being
+                    // deterministic.
+                    (lig2.len(), lig1).cmp(&(lig1.len(), lig2))
+                });
                 write_gsub::LigatureSet::new(
                     ligs.into_iter()
                         .map(|(components, lig_glyph)| {


### PR DESCRIPTION
This now matches the sorting behaviour of fontTools: longer sequences before shorter ones, and then in lexicographic order.