### PR TITLE
Contextual formats

### DIFF
--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -640,8 +640,8 @@ impl<'a> CompilationCtx<'a> {
 
         if (first_ids.is_class() || second_ids.is_class()) && node.enum_().is_none() {
             lookup.add_gpos_type_2_class(
-                first_ids.into_class().unwrap(),
-                second_ids.into_class().unwrap(),
+                first_ids.to_class().unwrap(),
+                second_ids.to_class().unwrap(),
                 first_value,
                 second_value,
             )

--- a/fea-rs/src/compile/lookups.rs
+++ b/fea-rs/src/compile/lookups.rs
@@ -323,7 +323,8 @@ impl AllLookups {
             match current {
                 SomeLookup::GsubLookup(lookup) => lookup.force_subtable_break(),
                 SomeLookup::GposLookup(lookup) => lookup.force_subtable_break(),
-                _ => (),
+                SomeLookup::GposContextual(lookup) => lookup.force_subtable_break(),
+                SomeLookup::GsubContextual(lookup) => lookup.force_subtable_break(),
             }
             true
         } else {

--- a/fea-rs/src/compile/lookups/gpos.rs
+++ b/fea-rs/src/compile/lookups/gpos.rs
@@ -168,8 +168,8 @@ impl ClassPairPosSubtable {
         record1: ValueRecord,
         record2: ValueRecord,
     ) {
-        self.classdef_1.add(class1.clone());
-        self.classdef_2.add(class2.clone());
+        self.classdef_1.checked_add(class1.clone());
+        self.classdef_2.checked_add(class2.clone());
         self.items
             .entry(class1)
             .or_default()

--- a/fea-rs/src/compile/lookups/helpers.rs
+++ b/fea-rs/src/compile/lookups/helpers.rs
@@ -41,9 +41,17 @@ impl ClassDefBuilder2 {
         self.classes.contains(cls) || cls.iter().all(|gid| !self.glyphs.contains(&gid))
     }
 
-    pub(crate) fn add(&mut self, cls: GlyphClass) {
-        self.glyphs.extend(cls.iter());
-        self.classes.insert(cls);
+    /// Check that this class can be added to this classdef, and add it if so.
+    ///
+    /// returns `true` if the class is added, and `false` otherwise.
+    pub(crate) fn checked_add(&mut self, cls: GlyphClass) -> bool {
+        if self.can_add(&cls) {
+            self.glyphs.extend(cls.iter());
+            self.classes.insert(cls);
+            true
+        } else {
+            false
+        }
     }
 
     /// Returns a compiled glyphclass, as well as a mapping from our class objects
@@ -84,12 +92,12 @@ mod tests {
     #[test]
     fn smoke_test_class_builder() {
         let mut builder = ClassDefBuilder2::new(false);
-        builder.add(make_glyph_class([6, 10]));
+        builder.checked_add(make_glyph_class([6, 10]));
         let (cls, _) = builder.build();
         assert_eq!(cls.get(GlyphId::new(6)), 1);
 
         let mut builder = ClassDefBuilder2::new(true);
-        builder.add(make_glyph_class([6, 10]));
+        builder.checked_add(make_glyph_class([6, 10]));
         let (cls, _) = builder.build();
         assert_eq!(cls.get(GlyphId::new(6)), 0);
         assert_eq!(cls.get(GlyphId::new(10)), 0);

--- a/fea-rs/src/types.rs
+++ b/fea-rs/src/types.rs
@@ -89,6 +89,13 @@ impl GlyphOrClass {
         }
     }
 
+    pub(crate) fn as_glyph(&self) -> Option<GlyphId> {
+        match self {
+            GlyphOrClass::Glyph(gid) => Some(*gid),
+            _ => None,
+        }
+    }
+
     pub(crate) fn iter(&self) -> impl Iterator<Item = GlyphId> + '_ {
         let mut idx = 0;
         std::iter::from_fn(move || {

--- a/fea-rs/src/types.rs
+++ b/fea-rs/src/types.rs
@@ -81,15 +81,15 @@ impl GlyphOrClass {
         matches!(self, GlyphOrClass::Class(_))
     }
 
-    pub(crate) fn into_class(self) -> Option<GlyphClass> {
+    pub(crate) fn to_class(&self) -> Option<GlyphClass> {
         match self {
-            GlyphOrClass::Glyph(gid) => Some(gid.into()),
-            GlyphOrClass::Class(class) => Some(class),
+            GlyphOrClass::Glyph(gid) => Some((*gid).into()),
+            GlyphOrClass::Class(class) => Some(class.clone()),
             GlyphOrClass::Null => None,
         }
     }
 
-    pub(crate) fn as_glyph(&self) -> Option<GlyphId> {
+    pub(crate) fn to_glyph(&self) -> Option<GlyphId> {
         match self {
             GlyphOrClass::Glyph(gid) => Some(*gid),
             _ => None,


### PR DESCRIPTION
This adds support for various subtable formats in contextual (and chain contextual) lookups.

A lot of this implementation uses feaLib as a reference.

Some funny stuff:

- for these subtables, fealib attempts to build all three formats, and then measures the final output size, picking the smallest. We adopt this as well, although it feels bad, and also doesn't tell the whole story; the final size of the generated binary depends on the tables it is compiled alongside, since this may provide the possibility of further space savings.
- Our size measurement code produces different results than does feaLib. In particular, in several tests our code will select format 3 over format 2 in places where feaLib does the opposite; this seems to be the result of us doing more efficient table packing.
