### PR TITLE
Parse, validate, and compile the 'aalt' feature

### DIFF
--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -450,12 +450,7 @@ impl<'a> CompilationCtx<'a> {
     }
 
     fn add_single_sub(&mut self, node: &typed::Gsub1) {
-        let target = node.target();
-        let replace = node.replacement();
-
-        if let Some((target, replacement)) =
-            self.validate_single_sub_inputs(&target, Some(&replace))
-        {
+        if let Some((target, replacement)) = self.resolve_single_sub_glyphs(node) {
             if replacement.is_null() {
                 // when the replacement is null, it means we are 'deleting' a glyph
                 // which uses a trick: we represent it as a multiple substitution
@@ -476,6 +471,12 @@ impl<'a> CompilationCtx<'a> {
         }
     }
 
+    fn resolve_single_sub_glyphs(
+        &mut self,
+        node: &typed::Gsub1,
+    ) -> Option<(GlyphOrClass, GlyphOrClass)> {
+        self.validate_single_sub_inputs(&node.target(), Some(&node.replacement()))
+    }
     //TODO: this should be in validate, but we don't have access to resolved
     //glyphs there right now :(
     fn validate_single_sub_inputs(

--- a/fea-rs/src/compile/lookups/contextual.rs
+++ b/fea-rs/src/compile/lookups/contextual.rs
@@ -240,6 +240,13 @@ impl ContextBuilder {
         })
     }
 
+    // for adjusting ids if we insert aalt at the front
+    pub(crate) fn bump_all_lookup_ids(&mut self, by: usize) {
+        self.rules
+            .iter_mut()
+            .for_each(|rule| rule.bump_all_lookup_ids(by))
+    }
+
     fn is_chain_rule(&self) -> bool {
         self.rules.iter().any(ContextRule::is_chain_rule)
     }
@@ -306,6 +313,13 @@ impl ContextBuilder {
 }
 
 impl ContextRule {
+    pub(crate) fn bump_all_lookup_ids(&mut self, by: usize) {
+        for (_, lookups) in &mut self.context {
+            lookups
+                .iter_mut()
+                .for_each(|x| *x = LookupId::Gsub(x.to_raw() + by))
+        }
+    }
     fn is_chain_rule(&self) -> bool {
         !self.backtrack.is_empty() || !self.lookahead.is_empty()
     }
@@ -366,6 +380,10 @@ impl Builder for ContextBuilder {
 }
 
 impl ChainContextBuilder {
+    pub(crate) fn bump_all_lookup_ids(&mut self, by: usize) {
+        self.0.bump_all_lookup_ids(by)
+    }
+
     fn build_format_1(&self) -> Option<write_layout::ChainedSequenceContext> {
         let coverage = self.0.format_1_coverage()?.build();
 

--- a/fea-rs/src/compile/lookups/gsub.rs
+++ b/fea-rs/src/compile/lookups/gsub.rs
@@ -35,6 +35,15 @@ impl SingleSubBuilder {
     pub fn contains_target(&self, target: GlyphId) -> bool {
         self.items.contains_key(&target)
     }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    // used when compiling aalt
+    pub(crate) fn iter_pairs(&self) -> impl Iterator<Item = (GlyphId, GlyphId)> + '_ {
+        self.items.iter().map(|(target, (alt, _))| (*target, *alt))
+    }
 }
 
 impl Builder for SingleSubBuilder {
@@ -165,6 +174,17 @@ pub struct AlternateSubBuilder {
 impl AlternateSubBuilder {
     pub fn insert(&mut self, target: GlyphId, replacement: Vec<GlyphId>) {
         self.items.insert(target, replacement);
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    // used when compiling aalt
+    pub(crate) fn iter_pairs(&self) -> impl Iterator<Item = (GlyphId, GlyphId)> + '_ {
+        self.items
+            .iter()
+            .flat_map(|(target, alt)| alt.iter().map(|alt| (*target, *alt)))
     }
 }
 

--- a/fea-rs/src/parse/grammar/feature.rs
+++ b/fea-rs/src/parse/grammar/feature.rs
@@ -102,9 +102,11 @@ fn statement(parser: &mut Parser, recovery: TokenSet, in_lookup: bool) -> bool {
         Kind::FeatureKw => {
             // aalt only
             if parser.matches(1, TokenSet::TAG_LIKE) && parser.matches(2, Kind::Semi) {
-                assert!(parser.eat(Kind::FeatureKw));
-                parser.expect_tag(TokenSet::EMPTY);
-                assert!(parser.eat(Kind::Semi));
+                parser.in_node(Kind::AaltFeatureNode, |parser| {
+                    assert!(parser.eat(Kind::FeatureKw));
+                    parser.expect_tag(TokenSet::EMPTY);
+                    parser.expect_recover(Kind::Semi, recovery);
+                });
             }
         }
         Kind::ParametersKw => metrics::parameters(parser, recovery),

--- a/fea-rs/src/token_tree/token.rs
+++ b/fea-rs/src/token_tree/token.rs
@@ -256,6 +256,7 @@ pub enum Kind {
     StatAxisValueLocationNode,
     StatAxisValueFlagNode,
     CvParamsNameNode,
+    AaltFeatureNode,
 }
 
 impl Kind {
@@ -510,6 +511,7 @@ impl std::fmt::Display for Kind {
             Self::Os2NumberListNode => write!(f, "Os2NumberListNode"),
             Self::Os2FamilyClassNode => write!(f, "Os2FamilyClassNode"),
             Self::CvParamsNameNode => write!(f, "CvParamsNameNode"),
+            Self::AaltFeatureNode => write!(f, "AaltFeatureNode"),
         }
     }
 }

--- a/fea-rs/src/token_tree/typed.rs
+++ b/fea-rs/src/token_tree/typed.rs
@@ -283,6 +283,8 @@ ast_enum!(StatAxisValueItem {
     Location(StatAxisLocation),
 });
 
+ast_node!(AaltFeature, Kind::AaltFeatureNode);
+
 ast_node!(Gsub1, Kind::GsubType1);
 ast_node!(Gsub2, Kind::GsubType2);
 ast_node!(Gsub3, Kind::GsubType3);
@@ -1552,5 +1554,11 @@ impl Parameters {
 
     pub fn range_end(&self) -> Option<FloatLike> {
         self.iter().filter_map(FloatLike::cast).nth(3)
+    }
+}
+
+impl AaltFeature {
+    pub fn feature(&self) -> Tag {
+        self.iter().find_map(Tag::cast).unwrap()
     }
 }


### PR DESCRIPTION
This was one of the last major things I had avoided, and it ended up not being *too* bad. Basically we need to generate this after doing everything else, but we also need to insert the newly generated lookups at the front of the lookup list. This means all of our previously computed looup indices are now incorrect, so we have to go and adjust them all.