### PR TITLE
Support deleting glyphs ('sub X by NULL')

### DIFF
--- a/fea-rs/src/types.rs
+++ b/fea-rs/src/types.rs
@@ -81,6 +81,10 @@ impl GlyphOrClass {
         matches!(self, GlyphOrClass::Class(_))
     }
 
+    pub(crate) fn is_null(&self) -> bool {
+        matches!(self, GlyphOrClass::Null)
+    }
+
     pub(crate) fn to_class(&self) -> Option<GlyphClass> {
         match self {
             GlyphOrClass::Glyph(gid) => Some((*gid).into()),


### PR DESCRIPTION
This is explicitly supported in the FEA spec, and explicitly forbidden in the OpenType spec, and apparently the FEA spec has won out.