### PR TITLE
Add compile::language_system module

### DIFF
--- a/fea-rs/src/compile.rs
+++ b/fea-rs/src/compile.rs
@@ -8,6 +8,7 @@ mod common;
 mod compile_ctx;
 mod features;
 mod glyph_range;
+mod language_system;
 mod lookups;
 mod output;
 mod tables;

--- a/fea-rs/src/compile/language_system.rs
+++ b/fea-rs/src/compile/language_system.rs
@@ -1,0 +1,66 @@
+//! helpers for managing tracking language systems
+
+use std::collections::HashSet;
+
+use write_fonts::types::Tag;
+
+use super::{common, lookups::FeatureKey};
+
+/// A script/language pair
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct LanguageSystem {
+    pub script: Tag,
+    pub language: Tag,
+}
+
+/// Track languagesystem statements
+///
+/// Seeing no statements is the same as seeing 'DFLT dflt'.
+#[derive(Clone, Debug)]
+pub(crate) struct DefaultLanguageSystems {
+    has_explicit_entry: bool,
+    items: HashSet<LanguageSystem>,
+}
+
+impl DefaultLanguageSystems {
+    pub(crate) fn insert(&mut self, system: LanguageSystem) {
+        if !self.has_explicit_entry {
+            self.items.clear();
+            self.has_explicit_entry = true;
+        }
+        self.items.insert(system);
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = LanguageSystem> + '_ {
+        self.items.iter().copied()
+    }
+}
+
+impl LanguageSystem {
+    pub(crate) fn to_feature_key(self, feature: Tag) -> FeatureKey {
+        let LanguageSystem { script, language } = self;
+        FeatureKey {
+            feature,
+            language,
+            script,
+        }
+    }
+}
+
+impl Default for LanguageSystem {
+    fn default() -> Self {
+        Self {
+            script: common::tags::SCRIPT_DFLT,
+            language: common::tags::LANG_DFLT,
+        }
+    }
+}
+
+impl Default for DefaultLanguageSystems {
+    fn default() -> Self {
+        Self {
+            has_explicit_entry: false,
+            items: HashSet::from_iter([LanguageSystem::default()]),
+        }
+    }
+}

--- a/fea-rs/src/compile/lookups.rs
+++ b/fea-rs/src/compile/lookups.rs
@@ -30,7 +30,7 @@ use crate::{
     Kind,
 };
 
-use super::{common, tables::ClassId};
+use super::{common, language_system::LanguageSystem, tables::ClassId};
 
 use contextual::{
     ChainContextBuilder, ContextBuilder, ContextualLookupBuilder, ReverseChainBuilder,
@@ -564,6 +564,13 @@ impl FeatureKey {
     pub(crate) fn language(mut self, language: Tag) -> Self {
         self.language = language;
         self
+    }
+
+    pub(crate) fn to_language_system(self) -> LanguageSystem {
+        LanguageSystem {
+            script: self.script,
+            language: self.language,
+        }
     }
 }
 


### PR DESCRIPTION
Another little bit of cleanup, letting us separate out logic related to tracking language systems.

This also adds a LanguageSystem type, to replace the tuple (Tag, Tag)