### PR TITLE
Force GPOS7 to GPOS8, matching fonttools

### DIFF
--- a/fea-rs/src/compile/lookups/contextual.rs
+++ b/fea-rs/src/compile/lookups/contextual.rs
@@ -251,6 +251,13 @@ impl ContextBuilder {
         self.rules.iter().any(ContextRule::is_chain_rule)
     }
 
+    /// Force this ContextBuilder into a ChainContextBuilder.
+    ///
+    /// Only useful so we can optionally choose to only build chain rules
+    pub(crate) fn into_chain_rule(self) -> ChainContextBuilder {
+        ChainContextBuilder(self)
+    }
+
     fn has_glyph_classes(&self) -> bool {
         self.rules.iter().any(ContextRule::has_glyph_classes)
     }


### PR DESCRIPTION
we may want to revert this at some point, but for now we prefer matching feaLib as closely as possible.

see https://github.com/fonttools/fonttools/pull/2540