### PR TITLE
Better handling of lookupflag

### DIFF
--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -307,7 +307,15 @@ impl<'a> CompilationCtx<'a> {
 
     fn set_script(&mut self, stmt: typed::Script) {
         let script = stmt.tag().to_raw();
+        if Some(script) == self.script {
+            return;
+        }
+
         self.script = Some(script);
+
+        self.lookup_flags = LookupFlag::empty();
+        self.cur_mark_filter_set = None;
+
         self.set_script_language(script, common::tags::LANG_DFLT, false, false);
     }
 


### PR DESCRIPTION
With this patch, we pass the `lookupflags.fea` test from fonttools.

mainly this means:

- correctly building all of GDEF, including the mark glyph set definitions and mark attach classdef
- reseting lookupflags on script statements, and ignoring redundant script statements