### PR TITLE
Docfest

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,6 @@ Some general design concepts:
   the end. For instance during parsing we will continue parsing after an error
   has occurred, and report all parse errors once parsing is complete.
 
-A goal of this tool is to focus on providing good diagnostics when encountering
-errors. In particular, we do not fail immediately when encounter
 
 [spec]: http://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html
 [rust analyzer]: https://github.com/rust-analyzer/rust-analyzer/

--- a/fea-rs/src/compile/output.rs
+++ b/fea-rs/src/compile/output.rs
@@ -25,6 +25,7 @@ use crate::{Diagnostic, GlyphMap};
 /// for generating the various OpenType tables.
 //TODO: ability to generate new errors during this final compilation step
 pub struct Compilation {
+    /// Any warnings that were generated during compilation
     pub warnings: Vec<Diagnostic>,
     pub(crate) tables: Tables,
     pub(crate) lookups: AllLookups,

--- a/fea-rs/src/diagnostic.rs
+++ b/fea-rs/src/diagnostic.rs
@@ -9,13 +9,18 @@ pub struct Span {
     end: u32,
 }
 
+/// A diagnostic level
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Level {
+    /// An unrecoverable error
     Error,
+    /// A warning: something the user may want to address, but which is non-fatal
     Warning,
+    /// Info. unused?
     Info,
 }
 
+/// A message, associated with a location in a file.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Message {
     pub text: String,
@@ -23,21 +28,26 @@ pub struct Message {
     pub span: Span,
 }
 
+/// A diagnostic, including a message and additional annotations
+//TODO: would this be more useful with additional annotations or a help field?
+//some fancy error reporting crates have these.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Diagnostic {
+    /// The main message for this diagnostic
     pub message: Message,
+    /// The diagnostic level
     pub level: Level,
-    annotations: Vec<Message>,
-    help: Option<String>,
 }
 
 impl Span {
+    /// Convert this span to a `Range<usize>`
     pub fn range(&self) -> Range<usize> {
         self.start as usize..self.end as usize
     }
 }
 
 impl Diagnostic {
+    /// Create a new diagnostic
     pub fn new(
         level: Level,
         file: FileId,
@@ -54,40 +64,30 @@ impl Diagnostic {
                 file,
             },
             level,
-            annotations: Vec::new(),
-            help: None,
         }
     }
 
+    /// Create a new error, at the provided location
     pub fn error(file: FileId, span: Range<usize>, message: impl Into<String>) -> Self {
         Diagnostic::new(Level::Error, file, span, message)
     }
 
+    /// Create a new warning, at the provided location
     pub fn warning(file: FileId, span: Range<usize>, message: impl Into<String>) -> Self {
         Diagnostic::new(Level::Warning, file, span, message)
     }
 
-    //pub fn annotation(mut self, text: impl Into<String>, span: Range<usize>) -> Self {
-    //self.annotations.push(Message {
-    //text: text.into(),
-    //span: span.into(),
-    //});
-    //self
-    //}
-
-    pub fn help(mut self, help: impl Into<String>) -> Self {
-        self.help = Some(help.into());
-        self
-    }
-
+    /// The diagnostic's message text
     pub fn text(&self) -> &str {
         &self.message.text
     }
 
+    /// The location of the main span, as a `Range<usize>`
     pub fn span(&self) -> Range<usize> {
         self.message.span.range()
     }
 
+    /// `true` if this diagnostic is an error
     pub fn is_error(&self) -> bool {
         matches!(self.level, Level::Error)
     }

--- a/fea-rs/src/lib.rs
+++ b/fea-rs/src/lib.rs
@@ -1,4 +1,6 @@
-//! Parsing the Adobe OpenType Feature File format.
+//! Parsing and compiling the Adobe OpenType Feature File format.
+
+#![deny(missing_docs)]
 
 mod compile;
 mod diagnostic;
@@ -12,6 +14,6 @@ mod tests;
 
 pub use compile::{compile, validate, Compilation};
 pub use diagnostic::{Diagnostic, Level};
-pub use parse::{parse_root_file, parse_src, ParseTree, Source, SyntaxError, TokenSet};
-pub use token_tree::{typed, Kind, Node, NodeOrToken};
+pub use parse::{parse_root_file, parse_src, FileId, ParseTree, Source, TokenSet};
+pub use token_tree::{typed, Kind, Node, NodeOrToken, Token};
 pub use types::{GlyphIdent, GlyphMap, GlyphName};

--- a/fea-rs/src/parse.rs
+++ b/fea-rs/src/parse.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 
 pub use context::{parse_src, HardError, IncludeStatement, ParseContext};
 pub use lexer::TokenSet;
-pub use parser::{Parser, SyntaxError};
+pub use parser::Parser;
 pub use source::{FileId, Source};
 pub use tree::ParseTree;
 

--- a/fea-rs/src/parse/parser.rs
+++ b/fea-rs/src/parse/parser.rs
@@ -47,19 +47,12 @@ struct PendingToken {
     token: Lexeme,
 }
 
-/// An error encountered while parsing.
-#[derive(Debug, Clone)]
-pub struct SyntaxError {
-    pub message: String,
-    pub range: Range<usize>,
-}
-
 /// A tag and its range.
 ///
 /// We often want to associate errors with tag locations, so we handle
 /// them specially.
 #[derive(Clone, Debug)]
-pub struct TagToken {
+pub(crate) struct TagToken {
     pub tag: Tag,
     pub range: Range<usize>,
 }

--- a/fea-rs/src/parse/source.rs
+++ b/fea-rs/src/parse/source.rs
@@ -54,9 +54,9 @@ pub struct SourceLoadError {
 
 impl FileId {
     /// A reserved FileId used during parsing.
-    pub const CURRENT_FILE: FileId = FileId(unsafe { NonZeroU32::new_unchecked(1) });
+    pub(crate) const CURRENT_FILE: FileId = FileId(unsafe { NonZeroU32::new_unchecked(1) });
 
-    pub fn next() -> FileId {
+    pub(crate) fn next() -> FileId {
         use std::sync::atomic;
         static COUNTER: atomic::AtomicU32 = atomic::AtomicU32::new(2);
         FileId(NonZeroU32::new(COUNTER.fetch_add(1, atomic::Ordering::Relaxed)).unwrap())
@@ -94,18 +94,22 @@ impl Source {
         }
     }
 
+    /// The raw text for this source
     pub fn text(&self) -> &str {
         &self.contents
     }
 
+    /// The path of the underlying file, if one exists
     pub fn path(&self) -> Option<&Path> {
         self.path.as_deref()
     }
 
+    /// The [`FileId`] for this source.
     pub fn id(&self) -> FileId {
         self.id
     }
 
+    /// Compute the line and column for a given utf-8 offset.
     pub fn line_col_for_offset(&self, offset: usize) -> (usize, usize) {
         let offset_idx = match self.line_offsets.binary_search(&offset) {
             Ok(x) => x,

--- a/fea-rs/src/parse/tree.rs
+++ b/fea-rs/src/parse/tree.rs
@@ -12,22 +12,30 @@ pub struct ParseTree {
 }
 
 impl ParseTree {
+    /// The root node for this parse tree
     pub fn root(&self) -> &Node {
         &self.root
     }
 
+    /// The root node, as typed AST node
     pub fn typed_root(&self) -> typed::Root {
         typed::Root::try_from_node(&self.root).expect("parse tree has invalid root node type")
     }
 
+    /// Return a refernce to the source map
     pub fn source_map(&self) -> &SourceMap {
         &self.map
     }
 
+    /// Return the source for this id, if it exists in the source map
     pub fn get_source(&self, id: FileId) -> Option<&Source> {
         self.sources.get(&id)
     }
 
+    /// Generate a string suitable for presenting a [`Diagnostic`] to the user.
+    ///
+    /// This associates the message with the appropriate source location and
+    /// syntax highlighting.
     pub fn format_diagnostic(&self, err: &Diagnostic) -> String {
         let mut s = String::new();
         let source = self.get_source(err.message.file).unwrap();

--- a/fea-rs/src/token_tree/token.rs
+++ b/fea-rs/src/token_tree/token.rs
@@ -1,5 +1,6 @@
 /// Kinds of tokens assigned during lexing and parsing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[allow(missing_docs)]
 #[repr(u16)]
 pub enum Kind {
     Eof, // the end of the input stream
@@ -282,7 +283,7 @@ impl Kind {
         )
     }
 
-    pub fn is_trivia(self) -> bool {
+    pub(crate) fn is_trivia(self) -> bool {
         matches!(self, Kind::Comment | Kind::Whitespace | Kind::Backslash)
     }
 }

--- a/fea-rs/src/types.rs
+++ b/fea-rs/src/types.rs
@@ -10,21 +10,36 @@ mod glyph_map;
 
 pub use glyph_map::GlyphMap;
 
+/// A glyph name
 pub type GlyphName = SmolStr;
 
+/// A glyph class, as used in the FEA spec.
+///
+/// This type is currently somewhat confused; in certain places the spec expects
+/// that a glyoh class is sorted and deduplicated, and in other places it expects
+/// a glyph class to be an arbitrary sequence of glyphs.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GlyphClass(Rc<[GlyphId]>);
 
+/// A glyph or glyph class.
+///
+/// Various places in the FEA spec accept either a single glyph or a glyph class.
 #[derive(Debug, Clone)]
 pub enum GlyphOrClass {
+    /// A resolved GlyphId
     Glyph(GlyphId),
+    /// A resolved glyph class
     Class(GlyphClass),
+    /// An explicit <NULL> glyph
     Null,
 }
 
+/// Either a glyph name or a CID
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum GlyphIdent {
+    /// A glyph name
     Name(GlyphName),
+    /// a CID
     Cid(u16),
 }
 

--- a/fea-rs/src/types/glyph_map.rs
+++ b/fea-rs/src/types/glyph_map.rs
@@ -5,7 +5,13 @@ use std::{
     iter::FromIterator,
 };
 
-//construct with collect() on an iterator of cids or names :shrug:
+/// A glyph map for mapping from raw glyph identifiers to numeral `GlyphId`s.
+///
+/// This is used to map from names or CIDS encountered in a FEA file to the actual
+/// GlyphIds that will be used in the final font.
+///
+/// Currently, the only way to construct this type is by calling `collect()`
+/// on an iterator of cids or names.
 #[derive(Clone, Debug, Default)]
 pub struct GlyphMap {
     names: HashMap<GlyphName, GlyphId>,
@@ -13,15 +19,18 @@ pub struct GlyphMap {
 }
 
 impl GlyphMap {
+    /// The total number of glyphs
     pub fn len(&self) -> usize {
         self.names.len() + self.cids.len()
     }
 
+    /// Returns `true` if this map contains no glyphs
     pub fn is_empty(&self) -> bool {
         self.names.is_empty() && self.cids.is_empty()
     }
 
-    // maybe just for testing?
+    /// Generates a reverse map of ids -> raw identifers (names or CIDs)
+    //  maybe just for testing?
     pub fn reverse_map(&self) -> BTreeMap<GlyphId, GlyphIdent> {
         self.names
             .iter()
@@ -34,6 +43,7 @@ impl GlyphMap {
             .collect()
     }
 
+    /// Return `true` if the map contains the provided `GlyphIdent`.
     pub fn contains<Q: ?Sized + sealed::AsGlyphIdent>(&self, key: &Q) -> bool {
         if let Some(name) = key.named() {
             self.names.contains_key(name)
@@ -44,6 +54,7 @@ impl GlyphMap {
         }
     }
 
+    /// Return the `GlyphId` for the provided `GlyphIdent`
     pub fn get<Q: ?Sized + sealed::AsGlyphIdent>(&self, key: &Q) -> Option<GlyphId> {
         if let Some(name) = key.named() {
             self.names.get(name).copied()

--- a/fea-rs/src/util/highlighting.rs
+++ b/fea-rs/src/util/highlighting.rs
@@ -5,6 +5,7 @@ use std::fmt::Write;
 use crate::{parse::Source, Diagnostic, Kind, Level};
 use ansi_term::{Colour, Style};
 
+/// Return the appropriate visual style for this token kind.
 pub fn style_for_kind(kind: Kind) -> Style {
     match kind {
         Kind::Comment => Style::new().fg(Colour::Yellow).dimmed(),

--- a/fea-rs/src/util/paths.rs
+++ b/fea-rs/src/util/paths.rs
@@ -12,6 +12,7 @@ use std::path::{Path, PathBuf};
 pub struct CanonicalPath(PathBuf);
 
 impl CanonicalPath {
+    /// Create a new canonical path.
     pub fn from_path(path: impl AsRef<Path>) -> std::io::Result<Self> {
         path.as_ref().canonicalize().map(CanonicalPath)
     }

--- a/fea-rs/src/util/pretty_diff.rs
+++ b/fea-rs/src/util/pretty_diff.rs
@@ -3,7 +3,7 @@
 //! This is taken directly from the pretty_assertions crate; it always prints
 //! using debug, which escapes newlines. We want newlines.
 //!
-//! source: https://github.com/colin-kiegel/rust-pretty-assertions/blob/main/pretty_assertions/src/lib.rs (MIT/Apache)
+//! source: <https://github.com/colin-kiegel/rust-pretty-assertions/blob/main/pretty_assertions/src/lib.rs> (MIT/Apache)
 
 use std::fmt;
 
@@ -15,6 +15,7 @@ use ansi_term::{
 const SIGN_RIGHT: char = '>'; // + > →
 const SIGN_LEFT: char = '<'; // - < ←
 
+/// Assert two strings are equal, printing a pretty diff on failure.
 #[macro_export]
 macro_rules! assert_eq_str {
     ($left:expr, $right:expr$(,)?) => ({


### PR DESCRIPTION
This adds #![deny(missing_docs)] at the top level, and then chases all the warnings.

In the process of converting various things to be pub(crate) I have also found a bunch of API surface that was not used, and which I could delete.

I'm not exactly sure what stuff we want to make public; I've mostly limited it to things that would be useful for syntax highlighting. We can always revisit this down the road.