### PR TITLE
Make compile module public

### DIFF
--- a/fea-rs/src/compile.rs
+++ b/fea-rs/src/compile.rs
@@ -1,4 +1,6 @@
-use crate::{parse::ParseTree, Diagnostic, GlyphMap};
+//! Compiling OpenType Layout tables
+
+use crate::{parse::ParseTree, Diagnostic, GlyphMap, GlyphName};
 
 use self::{compile_ctx::CompilationCtx, validate::ValidationCtx};
 
@@ -41,4 +43,22 @@ fn compile_impl<'a>(node: &'a ParseTree, glyph_map: &'a GlyphMap) -> Compilation
     let mut ctx = CompilationCtx::new(glyph_map, node.source_map());
     ctx.compile(&node.typed_root());
     ctx
+}
+
+static GLYPH_ORDER_KEY: &str = "public.glyphOrder";
+
+/// A helper function for extracting the glyph order from a UFO
+///
+/// If the public.glyphOrder key is missing, or the glyphOrder is malformed,
+/// this will return `None`.
+pub fn get_ufo_glyph_order(font: &norad::Font) -> Option<GlyphMap> {
+    font.lib
+        .get(GLYPH_ORDER_KEY)
+        .and_then(|val| val.as_array())
+        .and_then(|name_array| {
+            name_array
+                .iter()
+                .map(|val| val.as_string().map(GlyphName::new))
+                .collect()
+        })
 }

--- a/fea-rs/src/lib.rs
+++ b/fea-rs/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(missing_docs)]
 
-mod compile;
+pub mod compile;
 mod diagnostic;
 mod parse;
 mod token_tree;
@@ -12,7 +12,7 @@ pub mod util;
 #[cfg(test)]
 mod tests;
 
-pub use compile::{compile, validate, Compilation};
+pub use compile::Compilation;
 pub use diagnostic::{Diagnostic, Level};
 pub use parse::{parse_root_file, parse_src, FileId, ParseTree, Source, TokenSet};
 pub use token_tree::{typed, Kind, Node, NodeOrToken, Token};

--- a/fea-rs/src/tests/compile.rs
+++ b/fea-rs/src/tests/compile.rs
@@ -9,6 +9,7 @@ use write_fonts::{
 };
 
 use crate::{
+    compile,
     util::ttx::{self as test_utils, Report, TestCase, TestResult},
     GlyphMap, GlyphName,
 };
@@ -82,7 +83,7 @@ fn bad_test_body(path: &Path, glyph_map: &GlyphMap) -> Result<(), TestCase> {
             path: path.to_owned(),
             reason: TestResult::ParseFail(test_utils::stringify_diagnostics(&node, &errs)),
         }),
-        Ok(node) => match crate::compile(&node, glyph_map) {
+        Ok(node) => match compile::compile(&node, glyph_map) {
             Ok(_) => Err(TestCase {
                 path: path.to_owned(),
                 reason: TestResult::UnexpectedSuccess,
@@ -123,7 +124,7 @@ fn good_test_body(path: &Path, glyph_map: &GlyphMap) -> Result<(), TestCase> {
             path: path.to_owned(),
             reason: TestResult::ParseFail(test_utils::stringify_diagnostics(&node, &errs)),
         }),
-        Ok(node) => match crate::compile(&node, glyph_map) {
+        Ok(node) => match compile::compile(&node, glyph_map) {
             Ok(_thing) => Ok(()),
             Err(errs) => Err(TestCase {
                 path: path.to_owned(),


### PR DESCRIPTION
I want to add more helper methods in here, so instead of exporting various helpers at the top level, I would prefer to just have the module be public, and then the user can access methods through it.