### PR TITLE
Add compile::Opts, make 'generate post table' an option

### DIFF
--- a/fea-rs/src/bin/compile.rs
+++ b/fea-rs/src/bin/compile.rs
@@ -3,7 +3,10 @@
 use std::path::{Path, PathBuf};
 
 use clap::Parser;
-use fea_rs::{compile, GlyphMap, GlyphName};
+use fea_rs::{
+    compile::{self, Opts},
+    GlyphMap, GlyphName,
+};
 use write_fonts::types::GlyphId;
 
 /// Attempt to compile features into a font file.
@@ -51,8 +54,9 @@ fn main() -> Result<(), Error> {
     };
 
     let path = args.out_path();
+    let opts = Opts::new().make_post_table(args.post);
     let raw_font = compiled
-        .build_raw(&glyph_names)
+        .build_raw(&glyph_names, opts)
         .expect("ttf compile failed")
         .build();
 
@@ -129,6 +133,10 @@ struct Args {
     /// path to write the generated font. Defaults to 'compile-out.ttf'
     #[arg(short, long)]
     out_path: Option<PathBuf>,
+
+    /// Optionally write a post table to the generated font
+    #[arg(short, long)]
+    post: bool,
 }
 
 impl Args {

--- a/fea-rs/src/compile.rs
+++ b/fea-rs/src/compile.rs
@@ -4,6 +4,7 @@ use crate::{parse::ParseTree, Diagnostic, GlyphMap, GlyphName};
 
 use self::{compile_ctx::CompilationCtx, validate::ValidationCtx};
 
+pub use opts::Opts;
 pub use output::Compilation;
 
 mod common;
@@ -12,6 +13,7 @@ mod features;
 mod glyph_range;
 mod language_system;
 mod lookups;
+mod opts;
 mod output;
 mod tables;
 mod validate;
@@ -23,6 +25,14 @@ pub fn validate(node: &ParseTree, glyph_map: &GlyphMap) -> Vec<Diagnostic> {
 }
 
 /// Run the compilation pass (including validation)
+///
+/// On success, the output of this method is a [`Compilation`] object, which
+/// can be used to build a binary font.
+///
+/// # Note:
+///
+/// If you're trying to compile a font, you are better off running the main
+/// binary, which lives at src/bin/compile.rs.
 pub fn compile(node: &ParseTree, glyph_map: &GlyphMap) -> Result<Compilation, Vec<Diagnostic>> {
     let ctx = validate_impl(node, glyph_map);
     if ctx.errors.iter().any(Diagnostic::is_error) {

--- a/fea-rs/src/compile/opts.rs
+++ b/fea-rs/src/compile/opts.rs
@@ -1,0 +1,20 @@
+//! Options used during compilation
+
+/// Options for configuring compilation behaviour.
+#[derive(Clone, Debug, Default)]
+pub struct Opts {
+    pub(crate) make_post_table: bool,
+}
+
+impl Opts {
+    /// Create a new empty set of options
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// If `true`, we will generate a post table from the glyph map.
+    pub fn make_post_table(mut self, flag: bool) -> Self {
+        self.make_post_table = flag;
+        self
+    }
+}

--- a/fea-rs/src/tests/compile.rs
+++ b/fea-rs/src/tests/compile.rs
@@ -3,7 +3,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::{
-    compile,
+    compile::{self, Opts},
     util::ttx::{self as test_utils, Report, TestCase, TestResult},
     GlyphMap,
 };
@@ -120,7 +120,9 @@ fn good_test_body(path: &Path, glyph_map: &GlyphMap) -> Result<(), TestCase> {
         }),
         Ok(node) => match compile::compile(&node, glyph_map) {
             Ok(thing) => {
-                let mut x = thing.build_raw(glyph_map).unwrap();
+                let mut x = thing
+                    .build_raw(glyph_map, Opts::new().make_post_table(true))
+                    .unwrap();
                 x.build();
                 Ok(())
             }

--- a/fea-rs/src/types/glyph_map.rs
+++ b/fea-rs/src/types/glyph_map.rs
@@ -1,5 +1,8 @@
+use write_fonts::tables::post::Post;
+
 use super::{GlyphId, GlyphIdent, GlyphName};
 use std::{
+    borrow::Cow,
     collections::{BTreeMap, HashMap},
     convert::TryInto,
     iter::FromIterator,
@@ -63,6 +66,20 @@ impl GlyphMap {
         } else {
             unreachable!()
         }
+    }
+
+    /// Generate a post table from this glyph map
+    pub fn make_post_table(&self) -> Post {
+        let reverse = self.reverse_map();
+        let rev_vec = reverse
+            .values()
+            .map(|val| match val {
+                GlyphIdent::Name(s) => Cow::Borrowed(s.as_str()),
+                GlyphIdent::Cid(cid) => Cow::Owned(format!("cid{:05}", *cid)),
+            })
+            .collect::<Vec<_>>();
+
+        Post::new_v2(rev_vec.iter().map(Cow::as_ref))
     }
 }
 


### PR DESCRIPTION
This is the start of being a bit more disciplined about how we compile output. I do need to redo our compilation stuff at some point soon, but this is maybe a reasonable start?

The particular motivation here is that in order to have our ttx output match fonttools, we need to generate a post table. I was doing this in a hacky way in the ttx test binary, but I'd also like this option to be available during general compilation.