### PR TITLE
More robust lookup splitting

### DIFF
--- a/fea-rs/src/util.rs
+++ b/fea-rs/src/util.rs
@@ -14,32 +14,3 @@ pub use pretty_diff::write_line_diff;
 
 #[doc(hidden)]
 pub static SPACES: &str = "                                                                                                                                                                                    ";
-
-// just used for sanity checking
-pub(crate) fn is_sorted<T: PartialOrd>(slice: &[T]) -> bool {
-    if slice.len() > 2 {
-        let mut prev = &slice[0];
-        for item in &slice[1..] {
-            if prev > item {
-                return false;
-            }
-            prev = item;
-        }
-    }
-    true
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn is_sorted_() {
-        assert!(is_sorted::<u32>(&[]));
-        assert!(is_sorted(&[1]));
-        assert!(is_sorted(&[1, 1, 1]));
-        assert!(is_sorted(&[1, 2, 11, 11, 12]));
-        assert!(!is_sorted(&[3, 2, 11, 11, 12]));
-        assert!(!is_sorted(&[2, 11, 11, 12, 11]));
-    }
-}


### PR DESCRIPTION
During initial development, I didn't know if I would be expecting features to have mixed GPOS/GSUB lookups, and my initial logic for dealing with them, if they occured, was naive to the point of useless.

This reworks that logic to be much more robust, splitting lookups manually if needed.