### PR TITLE
Ensure no mixing of gsub/gpos lookups

### DIFF
--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -635,8 +635,14 @@ impl<'a> CompilationCtx<'a> {
                 }
 
                 for lookup in item.lookups() {
-                    let lookup = self.lookups.get_named(&lookup.label().text).unwrap(); // validated already
-                    lookups.push(lookup);
+                    let id = self.lookups.get_named(&lookup.label().text).unwrap(); // validated already
+                    if matches!(id, LookupId::Gpos(_)) {
+                        self.error(
+                            lookup.label().range(),
+                            "Invalid lookup: expected GSUB, found GPOS",
+                        );
+                    }
+                    lookups.push(id);
                 }
                 (glyphs, lookups)
             })
@@ -911,6 +917,12 @@ impl<'a> CompilationCtx<'a> {
 
                 for lookup in item.lookups() {
                     let id = self.lookups.get_named(&lookup.label().text).unwrap();
+                    if matches!(id, LookupId::Gsub(_)) {
+                        self.error(
+                            lookup.label().range(),
+                            "Invalid lookup type: expected GPOS, found GSUB",
+                        );
+                    }
                     lookups.push(id);
                 }
 

--- a/fea-rs/src/tests/compile.rs
+++ b/fea-rs/src/tests/compile.rs
@@ -82,10 +82,13 @@ fn bad_test_body(path: &Path, glyph_map: &GlyphMap) -> Result<(), TestCase> {
             })
         }
         Ok(node) => match compile::compile(&node, glyph_map) {
-            Ok(_) => Err(TestCase {
-                path: path.to_owned(),
-                reason: TestResult::UnexpectedSuccess,
-            }),
+            Ok(thing) => {
+                let _ = thing.build_raw(glyph_map, Default::default()).unwrap();
+                Err(TestCase {
+                    path: path.to_owned(),
+                    reason: TestResult::UnexpectedSuccess,
+                })
+            }
             Err(errs) => {
                 let msg = test_utils::stringify_diagnostics(&node, &errs);
                 let result =


### PR DESCRIPTION
This was inpsired by realizing that it was possible to have a chain rule that referenced a named lookup of the incorrect type.

To handle this, I now require the user to be explicit when converting a LookupId to a u16 about whether they are in a GPOS or GSUB context; this ensures that if lookupids somehow end up in the wrong place, we will at least crash.