### PR TITLE
Update fonttools tests

### DIFF
--- a/fea-rs/src/util/ttx.rs
+++ b/fea-rs/src/util/ttx.rs
@@ -21,11 +21,8 @@ use serde::{Deserialize, Serialize};
 
 static IGNORED_TESTS: &[&str] = &[
     // ## tests with invalid syntax ## //
-    "GSUB_5_formats.fea",
     "AlternateChained.fea",
     "GSUB_6.fea",
-    // https://github.com/adobe-type-tools/afdko/issues/1415
-    "bug509.fea",
     //
     // ## tests that should be revisited ## //
     //


### PR DESCRIPTION
As of https://github.com/fonttools/fonttools/pull/2950, a number of test cases that we had disabled have been modified in such a way that we can handle them correctly.

This updates the tests submodule, and removes those tests from the "do not run" list.