### PR TITLE
Set up logging

### DIFF
--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -24,6 +24,8 @@ serde = { version = "1.0.147", features = ["derive"], optional = true }
 serde_json = {version = "1.0.87", optional = true }
 thiserror = "1.0.37"
 clap = { version = "4.0.32", features = ["derive"] }
+log = "0.4"
+env_logger = "0.9.0"
 
 [features]
 test = ["diff", "rayon", "serde", "serde_json"]

--- a/fea-rs/src/bin/compile.rs
+++ b/fea-rs/src/bin/compile.rs
@@ -18,6 +18,7 @@ use fea_rs::{
 ///
 /// where glyph order is a file listing glyphs, one per line, in glyph id order.
 fn main() -> Result<(), Error> {
+    env_logger::init();
     let args = Args::parse();
     let (fea, glyph_names) = args.get_inputs()?;
     if !fea.exists() {
@@ -36,6 +37,12 @@ fn main() -> Result<(), Error> {
 
     let compiled = match compile::compile(&tree, &glyph_names) {
         Ok(compilation) => {
+            if !compilation.warnings.is_empty() {
+                log::warn!(
+                    "Compilation produced {} warnings",
+                    compilation.warnings.len()
+                );
+            }
             for warning in &compilation.warnings {
                 eprintln!("{}", tree.format_diagnostic(warning));
             }
@@ -51,7 +58,7 @@ fn main() -> Result<(), Error> {
                 }
             }
             let warning_count = errors.len() - err_count;
-            println!("{} errors, {} warnings", err_count, warning_count);
+            log::info!("{} errors, {} warnings", err_count, warning_count);
             std::process::exit(1);
         }
     };
@@ -63,7 +70,7 @@ fn main() -> Result<(), Error> {
         .expect("ttf compile failed")
         .build();
 
-    println!("writing {} bytes to {}", raw_font.len(), path.display());
+    log::info!("writing {} bytes to {}", raw_font.len(), path.display());
     std::fs::write(path, raw_font).map_err(Into::into)
 }
 

--- a/fea-rs/src/bin/parse_test.rs
+++ b/fea-rs/src/bin/parse_test.rs
@@ -36,7 +36,7 @@ fn directory_arg(path: &Path) -> std::io::Result<()> {
         let path = entry.path();
         if path.extension() == Some(OsStr::new("fea")) {
             seen += 1;
-            eprintln!("parsing '{}'", path.display());
+            log::info!("parsing '{}'", path.display());
             match std::panic::catch_unwind(|| try_parse_file(&path)) {
                 Err(_) => failures.push((path, true)),
                 Ok((_, errs)) if errs.iter().any(|e| e.is_error()) => failures.push((path, false)),

--- a/fea-rs/src/bin/ttx_test.rs
+++ b/fea-rs/src/bin/ttx_test.rs
@@ -55,7 +55,7 @@ fn save_wip_diffs(results: &ttx::Report) {
                 .join(file_name)
                 .with_extension("expected_diff");
             let diff = ttx::plain_text_diff(expected, result);
-            eprintln!("saved diff to {}", out_path.display());
+            log::info!("saved diff to {}", out_path.display());
             std::fs::write(out_path, diff).unwrap();
         }
     }


### PR DESCRIPTION
This brings in log & env_logger, although it does not use them much. Most of our errors are reported through the diagnostics mechanism, but logging will be useful going forward.