### PR TITLE
Clean up fixmes

### DIFF
--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -21,6 +21,7 @@ use crate::{
         typed::{self, AstNode},
         Token,
     },
+    typed::ContextualRuleNode,
     types::{GlyphClass, GlyphId, GlyphOrClass},
     Diagnostic, GlyphIdent, GlyphMap, Kind, NodeOrToken,
 };

--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -524,7 +524,7 @@ impl<'a> CompilationCtx<'a> {
         &mut self,
         node: &typed::Gsub1,
     ) -> Option<(GlyphOrClass, GlyphOrClass)> {
-        self.validate_single_sub_inputs(&node.target(), Some(&node.replacement()))
+        self.validate_single_sub_inputs(&node.target(), node.replacement().as_ref())
     }
     //TODO: this should be in validate, but we don't have access to resolved
     //glyphs there right now :(

--- a/fea-rs/src/compile/validate.rs
+++ b/fea-rs/src/compile/validate.rs
@@ -832,7 +832,9 @@ impl<'a> ValidationCtx<'a> {
             typed::GsubStatement::Type1(rule) => {
                 //TODO: ensure equal lengths, other requirements
                 self.validate_glyph_or_class(&rule.target());
-                self.validate_glyph_or_class(&rule.replacement());
+                if let Some(replacement) = rule.replacement() {
+                    self.validate_glyph_or_class(&replacement);
+                }
             }
             typed::GsubStatement::Type2(rule) => {
                 self.validate_glyph(&rule.target());

--- a/fea-rs/src/compile/validate.rs
+++ b/fea-rs/src/compile/validate.rs
@@ -23,6 +23,7 @@ use crate::{
         typed::{self, AstNode},
         Token,
     },
+    typed::ContextualRuleNode,
     Diagnostic, GlyphMap, Kind, NodeOrToken,
 };
 

--- a/fea-rs/src/compile/validate.rs
+++ b/fea-rs/src/compile/validate.rs
@@ -937,10 +937,6 @@ impl<'a> ValidationCtx<'a> {
                             self.error(class.range(), "class can only substitute another class");
                         }
                     } else if let Some(glyph) = inline.replacement_glyphs().next() {
-                        if input_class {
-                            //FIXME: what does everyone else do?
-                            self.error(glyph.range(), "glyph cannot replace class");
-                        }
                         self.validate_glyph(&glyph);
                     }
                 }

--- a/fea-rs/src/parse/context.rs
+++ b/fea-rs/src/parse/context.rs
@@ -99,18 +99,17 @@ impl IncludeStatement {
     /// The path part of the statement.
     ///
     /// For the statement `include(file.fea)`, this is `file.fea`.
-    pub fn path(&self) -> &str {
+    fn path(&self) -> &str {
         &self.0.path().text
     }
 
     /// The range of the entire include statement.
-    pub fn stmt_range(&self) -> Range<usize> {
+    fn stmt_range(&self) -> Range<usize> {
         self.0.range()
     }
 
     /// The range of just the path text.
-    //FIXME: is this accurate? has it seen a cursor yet?
-    pub fn path_range(&self) -> Range<usize> {
+    fn path_range(&self) -> Range<usize> {
         self.0.path().range()
     }
 }

--- a/fea-rs/src/parse/grammar/gsub.rs
+++ b/fea-rs/src/parse/grammar/gsub.rs
@@ -179,6 +179,12 @@ fn parse_rsub(parser: &mut Parser, recovery: TokenSet) -> AstKind {
         return AstKind::GsubNode;
     }
     if parser.eat(Kind::ByKw) {
+        if parser.matches(0, Kind::NullKw) {
+            parser.err("Although explicitly part of the FEA spec, 'by NULL' in rsub rules is meaningless.\nSee https://github.com/fonttools/fonttools/issues/2952 for more information");
+            parser.eat_until(recovery);
+            parser.expect_semi();
+            return AstKind::GsubNode;
+        }
         glyph::expect_glyph_or_glyph_class(parser, recovery);
     }
     parser.expect_semi();

--- a/fea-rs/src/parse/grammar/gsub.rs
+++ b/fea-rs/src/parse/grammar/gsub.rs
@@ -34,8 +34,10 @@ pub(crate) fn gsub(parser: &mut Parser, recovery: TokenSet) {
         }
 
         // sub glyph by (type 1 or 2)
-        //FIXME: gsub 1 also lets you omit the 'by' keyword
-        if parser.eat(Kind::ByKw) {
+        if parser.eat(Kind::Semi) {
+            // absense of 'by _' clause means 'by null
+            return AstKind::GsubType1;
+        } else if parser.eat(Kind::ByKw) {
             if parser.eat(Kind::NullKw) {
                 parser.expect_semi();
                 return AstKind::GsubType1;

--- a/fea-rs/src/parse/grammar/mod.rs
+++ b/fea-rs/src/parse/grammar/mod.rs
@@ -264,11 +264,9 @@ fn eat_ignore_statement_item(parser: &mut Parser, recovery: TokenSet) -> bool {
         continue;
     }
 
-    // expect a marked glyph
-    if !parser.eat(Kind::SingleQuote) {
-        parser.err_recover("Ignore statement must include one marked glyph", recovery);
-    } else {
-        // eat all marked glyphs
+    // expect a marked glyph.
+    // if this is omitted we will continue parsing, and warn when we rewrite.
+    if parser.eat(Kind::SingleQuote) {
         loop {
             glyph::eat_glyph_or_glyph_class(parser, recovery);
             if !parser.eat(Kind::SingleQuote) {

--- a/fea-rs/src/token_tree/typed.rs
+++ b/fea-rs/src/token_tree/typed.rs
@@ -711,11 +711,10 @@ impl Gsub1 {
         self.iter().find_map(GlyphOrClass::cast).unwrap()
     }
 
-    pub(crate) fn replacement(&self) -> GlyphOrClass {
+    pub(crate) fn replacement(&self) -> Option<GlyphOrClass> {
         self.iter()
             .skip_while(|t| t.kind() != Kind::ByKw)
             .find_map(GlyphOrClass::cast)
-            .unwrap()
     }
 }
 


### PR DESCRIPTION
This is a rollup of commits of me addressing a number of lingering FIXMEs & TODOS.

- add a trait to generalize the backtrack/input/lookahead pattern common to various AST nodes
- verify that we have the correct range when reporting unresolved include statements
- validate the input of the OS/2 FamilyClass field
- disallow 'by NULL' in rsub rules
- support GSUB1 rules that omit the 'by' clause.