### PR TITLE
Support in-memory compilation

### DIFF
--- a/fea-lsp/src/document.rs
+++ b/fea-lsp/src/document.rs
@@ -1,6 +1,6 @@
 use std::{ops::Range, sync::Mutex};
 
-use fea_rs::{Kind, Source};
+use fea_rs::Kind;
 use lspower::lsp::{
     Diagnostic, DiagnosticSeverity, Position, Range as UghRange, SemanticToken, SemanticTokenType,
     SemanticTokens,
@@ -164,8 +164,7 @@ fn compute_offsets(text: &str) -> Vec<usize> {
 }
 
 fn parse(text: &str) -> (Vec<(Kind, Range<usize>)>, Vec<fea_rs::Diagnostic>) {
-    let src = Source::from_text(text);
-    let (root, errors, _) = fea_rs::parse_src(&src, None);
+    let (root, errors) = fea_rs::parse::parse_string(text);
     let result = root.iter_tokens().map(|t| (t.kind, t.range())).collect();
     (result, errors)
 }

--- a/fea-rs/benches/parsing.rs
+++ b/fea-rs/benches/parsing.rs
@@ -1,27 +1,29 @@
 //! A very simple benchmark for the parser
 
+use std::sync::Arc;
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 const DEVA: &str = include_str!("../test-data/real-files/plex_devanagari.fea");
 const LATN: &str = include_str!("../test-data/real-files/roboto-regular.fea");
 const ARAB: &str = include_str!("../test-data/real-files/tajawal-regular.fea");
 
-fn parse_source(source: &fea_rs::Source) -> fea_rs::Node {
-    fea_rs::parse_src(source, None).0
+fn parse_source(source: Arc<str>) -> fea_rs::Node {
+    fea_rs::parse::parse_string(source).0
 }
 
 fn parsing(c: &mut Criterion) {
-    let deva = fea_rs::Source::from_text(DEVA);
-    let latn = fea_rs::Source::from_text(LATN);
-    let arab = fea_rs::Source::from_text(ARAB);
+    let deva: Arc<str> = DEVA.into();
+    let latn: Arc<str> = LATN.into();
+    let arab: Arc<str> = ARAB.into();
     c.bench_function("parse plex-devenagari", |b| {
-        b.iter(|| parse_source(black_box(&deva)))
+        b.iter(|| parse_source(black_box(deva.clone())))
     });
     c.bench_function("parse roboto-regular", |b| {
-        b.iter(|| parse_source(black_box(&latn)))
+        b.iter(|| parse_source(black_box(latn.clone())))
     });
     c.bench_function("parse tajawal-regular", |b| {
-        b.iter(|| parse_source(black_box(&arab)))
+        b.iter(|| parse_source(black_box(arab.clone())))
     });
 }
 

--- a/fea-rs/benches/parsing.rs
+++ b/fea-rs/benches/parsing.rs
@@ -1,6 +1,6 @@
 //! A very simple benchmark for the parser
 
-use std::sync::Arc;
+use std::rc::Rc;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
@@ -8,14 +8,14 @@ const DEVA: &str = include_str!("../test-data/real-files/plex_devanagari.fea");
 const LATN: &str = include_str!("../test-data/real-files/roboto-regular.fea");
 const ARAB: &str = include_str!("../test-data/real-files/tajawal-regular.fea");
 
-fn parse_source(source: Arc<str>) -> fea_rs::Node {
+fn parse_source(source: Rc<str>) -> fea_rs::Node {
     fea_rs::parse::parse_string(source).0
 }
 
 fn parsing(c: &mut Criterion) {
-    let deva: Arc<str> = DEVA.into();
-    let latn: Arc<str> = LATN.into();
-    let arab: Arc<str> = ARAB.into();
+    let deva: Rc<str> = DEVA.into();
+    let latn: Rc<str> = LATN.into();
+    let arab: Rc<str> = ARAB.into();
     c.bench_function("parse plex-devenagari", |b| {
         b.iter(|| parse_source(black_box(deva.clone())))
     });

--- a/fea-rs/src/bin/compile.rs
+++ b/fea-rs/src/bin/compile.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), Error> {
     if !fea.exists() {
         return Err(Error::EmptyFeatureFile);
     }
-    let parse = fea_rs::parse_root_file(&fea, Some(&glyph_names), None).unwrap();
+    let parse = fea_rs::parse::parse_root_file(&fea, Some(&glyph_names), None).unwrap();
     let (tree, diagnostics) = parse.generate_parse_tree();
     let mut has_error = false;
     for msg in &diagnostics {

--- a/fea-rs/src/bin/highlight.rs
+++ b/fea-rs/src/bin/highlight.rs
@@ -4,8 +4,8 @@ use std::{env, ffi::OsStr, path::PathBuf};
 
 fn main() {
     let args = Args::get_from_env_or_exit();
-    let parse = fea_rs::parse_root_file(args.path, None, None).unwrap();
-    let (node, _errors) = parse.get_raw(parse.root_id()).unwrap();
+    let raw_fea = std::fs::read_to_string(args.path).unwrap();
+    let (node, _errors) = fea_rs::parse::parse_string(raw_fea);
     let mut current_style = Style::new().fg(Colour::White);
     let mut needs_paint = String::new();
 

--- a/fea-rs/src/bin/parse_test.rs
+++ b/fea-rs/src/bin/parse_test.rs
@@ -75,7 +75,7 @@ fn single_file_arg(path: &Path, print_tree: bool) {
 
 /// returns the tree and any errors
 fn try_parse_file(path: &Path) -> (ParseTree, Vec<Diagnostic>) {
-    let parse = fea_rs::parse_root_file(path, None, None).unwrap();
+    let parse = fea_rs::parse::parse_root_file(path, None, None).unwrap();
     parse.generate_parse_tree()
 }
 

--- a/fea-rs/src/lib.rs
+++ b/fea-rs/src/lib.rs
@@ -4,7 +4,7 @@
 
 pub mod compile;
 mod diagnostic;
-mod parse;
+pub mod parse;
 mod token_tree;
 mod types;
 pub mod util;
@@ -14,6 +14,6 @@ mod tests;
 
 pub use compile::Compilation;
 pub use diagnostic::{Diagnostic, Level};
-pub use parse::{parse_root_file, parse_src, FileId, ParseTree, Source, TokenSet};
+pub use parse::{ParseTree, TokenSet};
 pub use token_tree::{typed, Kind, Node, NodeOrToken, Token};
 pub use types::{GlyphIdent, GlyphMap, GlyphName};

--- a/fea-rs/src/parse.rs
+++ b/fea-rs/src/parse.rs
@@ -10,7 +10,7 @@ mod parser;
 mod source;
 mod tree;
 
-use std::{ffi::OsString, path::PathBuf, sync::Arc};
+use std::{ffi::OsString, path::PathBuf, rc::Rc};
 
 pub use context::{IncludeStatement, ParseContext};
 pub use lexer::TokenSet;
@@ -72,7 +72,9 @@ pub fn parse_root(
 ///
 /// This is useful for things like testing or syntax highlighting of a single file,
 /// but it cannot handle imports, or handle ambiguous glyph names.
-pub fn parse_string(text: impl Into<Arc<str>>) -> (Node, Vec<Diagnostic>) {
+///
+/// The input text can be any of `&str`, `String`, or `Rc<str>`.
+pub fn parse_string(text: impl Into<Rc<str>>) -> (Node, Vec<Diagnostic>) {
     let source = source::Source::new("<parse::parse_string>", text.into());
     let (node, errs, _) = context::parse_src(&source, None);
     (node, errs)

--- a/fea-rs/src/parse.rs
+++ b/fea-rs/src/parse.rs
@@ -1,29 +1,79 @@
-//! Convert raw tokens into semantic events
+//! Load and tokenize sources.
+//!
+//! In general, you should not need to use this module directly; it is exposed
+//! so that it can be used for things like syntax highlighting.
 
 mod context;
-pub mod grammar;
+pub(crate) mod grammar;
 mod lexer;
 mod parser;
 mod source;
 mod tree;
 
-use std::path::PathBuf;
+use std::{ffi::OsString, path::PathBuf, sync::Arc};
 
-pub use context::{parse_src, HardError, IncludeStatement, ParseContext};
+pub use context::{IncludeStatement, ParseContext};
 pub use lexer::TokenSet;
 pub use parser::Parser;
-pub use source::{FileId, Source};
+pub use source::{Source, SourceLoadError, SourceResolver};
 pub use tree::ParseTree;
 
-pub(crate) use source::{SourceList, SourceMap};
+pub(crate) use source::{FileId, SourceList, SourceMap};
 
-use crate::GlyphMap;
+use crate::{Diagnostic, GlyphMap, Node};
 
-/// Attempt to parse a feature file at a given path, including its imports.
+/// Attempt to parse a feature file from disk, including its imports.
+///
+/// In general, you should not need to use this method directly; instead use one
+/// of the methods in the [`compile`][crate::compile] module.
+///
+/// The `project_root` argument is optional, and is intended for the case of
+/// handling UFO files, where imports are resolved relative to the root directory,
+/// and not the feature file itself.
+///
+/// The `glyph_map`, if provided, is used to disambiguate between certain tokens
+/// that are allowed in FEA syntax but which are also legal glyph names. If it
+/// is absent, and these names are encountered, we will report an error.
+///
+/// If you are compiling from memory, or otherwise want to handle loading files
+/// and resolving imports, you can use [`parse_root`] instead.
 pub fn parse_root_file(
     path: impl Into<PathBuf>,
     glyph_map: Option<&GlyphMap>,
     project_root: Option<PathBuf>,
-) -> Result<ParseContext, HardError> {
-    ParseContext::parse_from_root(path.into(), glyph_map, project_root)
+) -> Result<ParseContext, SourceLoadError> {
+    let path = path.into();
+    let project_root =
+        project_root.unwrap_or_else(|| path.parent().map(PathBuf::from).unwrap_or_default());
+    let resolver = source::FileSystemResolver::new(project_root);
+    parse_root(path.into_os_string(), glyph_map, resolver)
+}
+
+/// Entry point for parsing.
+///
+/// This method provides full control over how sources are located and include
+/// statements are resolved, by allowing you to provide a custom [`SourceResolver`].
+///
+/// The `path` argument is identifies the root source; it will be resolved against
+/// the provided `resolver`.
+///
+/// The `glyph_map`, if provided, is used to disambiguate between certain tokens
+/// that are allowed in FEA syntax but which are also legal glyph names. If you
+/// are not compiling the parse results, you can omit it.
+pub fn parse_root(
+    path: OsString,
+    glyph_map: Option<&GlyphMap>,
+    resolver: impl SourceResolver + 'static,
+) -> Result<ParseContext, SourceLoadError> {
+    ParseContext::parse_from_root(path.into(), glyph_map, resolver)
+}
+
+/// Convenience method to parse a block of FEA from memory.
+///
+/// This is useful for things like testing or syntax highlighting of a single file,
+/// but it cannot handle imports, or handle ambiguous glyph names.
+pub fn parse_string(text: impl Into<Arc<str>>) -> (Node, Vec<Diagnostic>) {
+    let source = source::Source::new("<parse::parse_string>", text.into());
+    let (node, errs, _) = context::parse_src(&source, None);
+    (node, errs)
 }

--- a/fea-rs/src/parse/grammar/mod.rs
+++ b/fea-rs/src/parse/grammar/mod.rs
@@ -304,7 +304,7 @@ fn debug_parse_output(
 ) -> (crate::Node, Vec<crate::Diagnostic>, String) {
     use super::Source;
 
-    let source = Source::from_text(text);
+    let source = Source::new("debug_parse_output", text.into());
     let mut sink = crate::token_tree::AstSink::new(text, source.id(), None);
     let mut parser = Parser::new(text, &mut sink);
     f(&mut parser);

--- a/fea-rs/src/parse/source.rs
+++ b/fea-rs/src/parse/source.rs
@@ -8,7 +8,6 @@ use std::{
     ops::Range,
     path::{Path, PathBuf},
     rc::Rc,
-    sync::Arc,
 };
 
 use crate::util;
@@ -26,10 +25,10 @@ pub struct Source {
     id: FileId,
     /// The non-canonicalized path to this source, suitable for printing.
     path: OsString,
-    contents: Arc<str>,
+    contents: Rc<str>,
     /// The index of each newline character, for efficiently fetching lines
     /// (for error reporting, e.g.)
-    line_offsets: Arc<[usize]>,
+    line_offsets: Rc<[usize]>,
 }
 
 /// A list of sources in a project.
@@ -165,7 +164,7 @@ impl FileId {
 }
 
 impl Source {
-    pub(crate) fn new(path: impl Into<OsString>, contents: Arc<str>) -> Self {
+    pub(crate) fn new(path: impl Into<OsString>, contents: Rc<str>) -> Self {
         let line_offsets = line_offsets(&contents);
         Source {
             path: path.into(),
@@ -232,7 +231,7 @@ impl Source {
     }
 }
 
-fn line_offsets(text: &str) -> Arc<[usize]> {
+fn line_offsets(text: &str) -> Rc<[usize]> {
     // we could use memchar for this; benefits would require benchmarking
     let mut result = vec![0];
     result.extend(

--- a/fea-rs/src/token_tree.rs
+++ b/fea-rs/src/token_tree.rs
@@ -610,14 +610,12 @@ impl std::fmt::Debug for Node {
 #[cfg(test)]
 mod tests {
 
-    use crate::parse::Source;
-
     use super::*;
     static SAMPLE_FEA: &str = include_str!("../test-data/fonttools-tests/mini.fea");
 
     #[test]
     fn token_iter() {
-        let (root, _errs, _) = crate::parse_src(&Source::from_text(SAMPLE_FEA), None);
+        let (root, _errs) = crate::parse::parse_string(SAMPLE_FEA);
         let reconstruct = root.iter_tokens().map(Token::as_str).collect::<String>();
         crate::assert_eq_str!(SAMPLE_FEA, reconstruct);
     }

--- a/fea-rs/src/token_tree/cursor.rs
+++ b/fea-rs/src/token_tree/cursor.rs
@@ -199,16 +199,13 @@ impl std::fmt::Debug for NodeRef<'_> {
 
 #[cfg(test)]
 mod tests {
-    use crate::parse::Source;
-
     use super::*;
 
     static SAMPLE_FEA: &str = include_str!("../../test-data/fonttools-tests/mini.fea");
 
     #[test]
     fn abs_positions() {
-        let fea = Source::from_text(SAMPLE_FEA);
-        let (root, errs, _) = crate::parse_src(&fea, None);
+        let (root, errs) = crate::parse::parse_string(SAMPLE_FEA);
         assert!(errs.is_empty());
         let mut last_end = 0;
         for token in root.iter_tokens() {
@@ -225,8 +222,7 @@ mod tests {
 
     #[test]
     fn ascend_jump() {
-        let fea = Source::from_text(SAMPLE_FEA);
-        let (root, _errs, _) = crate::parse_src(&fea, None);
+        let (root, _errs) = crate::parse::parse_string(SAMPLE_FEA);
         let mut cursor = root.cursor();
         cursor.advance();
         cursor.advance();
@@ -262,8 +258,7 @@ mod tests {
 
     #[test]
     fn advance() {
-        let fea = Source::from_text("feature kern { pos a b -20; }kern;");
-        let (root, errs, _) = crate::parse_src(&fea, None);
+        let (root, errs) = crate::parse::parse_string("feature kern { pos a b -20; }kern;");
         assert!(errs.is_empty());
         let mut cursor = root.cursor();
         assert!(

--- a/fea-rs/src/util/highlighting.rs
+++ b/fea-rs/src/util/highlighting.rs
@@ -1,6 +1,6 @@
 //! syntax highlighting functions
 
-use std::fmt::Write;
+use std::{fmt::Write, path::Path};
 
 use crate::{parse::Source, Diagnostic, Kind, Level};
 use ansi_term::{Colour, Style};
@@ -133,23 +133,15 @@ fn write_header(writer: &mut impl Write, err: &Diagnostic, source: &Source) {
     write!(writer, "{}{}: {}", color.prefix(), text, color.suffix(),).unwrap();
 
     writeln!(writer, "{}", &err.message.text).unwrap();
-    if let Some(path) = source.path() {
-        let (line, column) = source.line_col_for_offset(err.message.span.range().start);
-        let pre = Colour::Blue.italic().prefix();
-        let suf = Colour::Blue.italic().suffix();
-        writeln!(
-            writer,
-            "{}in{} {} {}at{} {}:{}",
-            pre,
-            suf,
-            path.display(),
-            pre,
-            suf,
-            line,
-            column
-        )
-        .unwrap();
-    }
+    let (line, column) = source.line_col_for_offset(err.message.span.range().start);
+    let pre = Colour::Blue.italic().prefix();
+    let suf = Colour::Blue.italic().suffix();
+    writeln!(
+        writer,
+        "{pre}in{suf} {} {pre}at{suf} {line}:{column}",
+        Path::new(source.path()).display(),
+    )
+    .unwrap();
 }
 
 impl Level {
@@ -184,7 +176,7 @@ mod tests {
     fn highlight_long_line() {
         static A_BAD_LINE: &str = "@COMBINING_MARKS = [ candrabindu-kannada nukta-kannada ssa-kannada.below.kssa ra-kannada.below rVocalicMatra-kannada rrVocalicMatra-kannada ailength-kannada ka-kannada.below kha-kannada.below ga-kannada.below gha-kannada.below nga-kannada.below ca-kannada.below cha-kannada.below ja-kannada.below jha-kannada.below nya-kannada.below tta-kannada.below ttha-kannada.below dda-kannada.below ddha-kannada.below nna-kannada.below ta-kannada.below tha-kannada.below da-kannada.below dha-kannada.below na-kannada.below pa-kannada.below pha-kannada.below ba-kannada.below bha-kannada.below ma-kannada.below ya-kannada.below la-kannada.below va-kannada.below sha-kannada.below ssa-kannada.below sa-kannada.below ha-kannada.below rra-kannada.below lla-kannada.below fa-kannada.below ka_ssa-kannada.below ta_ra-kannada.below ra-kannada.below.following rVocalicMatra-kannada.following rrVocalicMatra-kannada.following ailength-kannada.following ka-kannada.below.following kha-kannada.below.following ga-kannada.below.following gha-kannada.below.following nga-kannada.below.following ca-kannada.below.following cha-kannada.below.following ja-kannada.below.following jha-kannada.below.following nya-kannada.below.following tta-kannada.below.following ttha-kannada.below.following dda-kannada.below.following ddha-kannada.below.following nna-kannada.below.following ta-kannada.below.following tha-kannada.below.following da-kannada.below.following dha-kannada.below.following na-kannada.below.following pa-kannada.below.following pha-kannada.below.following ba-kannada.below.following bha-kannada.below.following ma-kannada.below.following ya-kannada.below.following la-kannada.below.following va-kannada.below.following sha-kannada.below.following ssa-kannada.below.following sa-kannada.below.following ha-kannada.below.following rra-kannada.below.following lla-kannada.below.following fa-kannada.below.following ka_ssa-kannada.below.following ta_ra-kannada.below.following ];";
 
-        let source = Source::from_text(A_BAD_LINE);
+        let source = Source::new("test", A_BAD_LINE.into());
         let err = Diagnostic::warning(source.id(), 200..220, "bad!");
         let mut write_to = String::new();
         write_diagnostic(&mut write_to, &err, &source, None);

--- a/fea-rs/src/util/ttx.rs
+++ b/fea-rs/src/util/ttx.rs
@@ -205,7 +205,7 @@ pub fn try_parse_file(
     path: &Path,
     glyphs: Option<&GlyphMap>,
 ) -> Result<ParseTree, (ParseTree, Vec<Diagnostic>)> {
-    let ctx = crate::parse_root_file(path, glyphs, None).unwrap();
+    let ctx = crate::parse::parse_root_file(path, glyphs, None).unwrap();
     let (tree, errs) = ctx.generate_parse_tree();
     if errs.iter().any(Diagnostic::is_error) {
         Err((tree, errs))


### PR DESCRIPTION
This patch introduces a new trait, `SourceResolver`, which abstracts out the task of finding and loading the FEA for a given path, both for the root source as well as for any additional sources referenced by `include($source)` statements.

The logic around includes in FEA is complicated; depending on the implementation, include statements may be resolved relative to the *root* fea file, to the *including* file, or to a parent directory. Previously this resolution logic was spread out across various places; it now is generally isolated to the internal `FileSystemResolver` type.


This PR really started to get away from me; I have some more changes I now want to make around what types are exposed via the public API, but I want to checkpoint this here now before it balloons any further.


closes #115 