### PR TITLE
Compiler API

### DIFF
--- a/fea-rs/benches/parsing.rs
+++ b/fea-rs/benches/parsing.rs
@@ -1,6 +1,6 @@
 //! A very simple benchmark for the parser
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
@@ -8,14 +8,14 @@ const DEVA: &str = include_str!("../test-data/real-files/plex_devanagari.fea");
 const LATN: &str = include_str!("../test-data/real-files/roboto-regular.fea");
 const ARAB: &str = include_str!("../test-data/real-files/tajawal-regular.fea");
 
-fn parse_source(source: Rc<str>) -> fea_rs::Node {
+fn parse_source(source: Arc<str>) -> fea_rs::Node {
     fea_rs::parse::parse_string(source).0
 }
 
 fn parsing(c: &mut Criterion) {
-    let deva: Rc<str> = DEVA.into();
-    let latn: Rc<str> = LATN.into();
-    let arab: Rc<str> = ARAB.into();
+    let deva: Arc<str> = DEVA.into();
+    let latn: Arc<str> = LATN.into();
+    let arab: Arc<str> = ARAB.into();
     c.bench_function("parse plex-devenagari", |b| {
         b.iter(|| parse_source(black_box(deva.clone())))
     });

--- a/fea-rs/src/bin/compile.rs
+++ b/fea-rs/src/bin/compile.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Error> {
     let path = args.out_path();
     let opts = Opts::new().make_post_table(args.post);
     let raw_font = compiled
-        .build_raw(&glyph_names, opts)
+        .assemble(&glyph_names, opts)
         .expect("ttf compile failed")
         .build();
 

--- a/fea-rs/src/compile/compiler.rs
+++ b/fea-rs/src/compile/compiler.rs
@@ -1,0 +1,132 @@
+//! The main public API for compilation
+
+#![allow(dead_code)]
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+};
+
+use crate::{
+    parse::{FileSystemResolver, SourceResolver},
+    Compilation, Diagnostic, GlyphMap, ParseTree,
+};
+
+use super::{
+    error::{CompilerError, DiagnosticSet},
+    Opts,
+};
+
+/// A builder-style entry point for the compiler
+#[derive(Debug)]
+pub struct Compiler<'a> {
+    root_path: OsString,
+    project_root: Option<PathBuf>,
+    glyph_map: &'a GlyphMap,
+    verbose: bool,
+    opts: Opts,
+    resolver: Option<Box<dyn SourceResolver>>,
+}
+
+impl<'a> Compiler<'a> {
+    /// Configure a new compilation run with a root source and a glyph map.
+    ///
+    /// In the general case, `root_path` will be a path to a feature file on disk;
+    /// however you may compile from memory by passing a custom `[SourceResolver`]
+    /// to the [`with_resolver`] method, in which case `root_path` can be any
+    /// identifier that your resolver will resolve.
+    pub fn new(root_path: impl Into<OsString>, glyph_map: &'a GlyphMap) -> Self {
+        Compiler {
+            root_path: root_path.into(),
+            glyph_map,
+            opts: Default::default(),
+            verbose: false,
+            resolver: Default::default(),
+            project_root: Default::default(),
+        }
+    }
+
+    /// Provide a custom `SourceResolver`, for mapping paths to their contents.
+    pub fn with_resolver(mut self, resolver: impl SourceResolver + 'static) -> Self {
+        self.resolver = Some(Box::new(resolver));
+        self
+    }
+
+    /// Specify verbosity.
+    ///
+    /// When verbose is true, we will print all warnings.
+    pub fn verbose(mut self, verbose: bool) -> Self {
+        self.verbose = verbose;
+        self
+    }
+
+    /// Specify an explicit project root.
+    ///
+    /// This is useful in cases where import resolution is based on an explicit
+    /// base directory, such as when dealing with certain source formats.
+    pub fn with_project_root(mut self, project_root: impl Into<PathBuf>) -> Self {
+        self.project_root = Some(project_root.into());
+        self
+    }
+
+    /// Specify additional compiler options.
+    pub fn with_opts(mut self, opts: Opts) -> Self {
+        self.opts = opts;
+        self
+    }
+
+    /// Parse, validate and compile this source.
+    pub fn compile(self) -> Result<Compilation, CompilerError> {
+        let resolver = self.resolver.unwrap_or_else(|| {
+            let project_root = self.project_root.unwrap_or_else(|| {
+                Path::new(&self.root_path)
+                    .parent()
+                    .map(PathBuf::from)
+                    .unwrap_or_default()
+            });
+            Box::new(FileSystemResolver::new(project_root))
+        });
+
+        let (tree, diagnostics) =
+            crate::parse::ParseContext::parse(self.root_path, Some(self.glyph_map), resolver)?
+                .generate_parse_tree();
+        print_warnings_return_errors(diagnostics, &tree, self.verbose)
+            .map_err(CompilerError::ParseFail)?;
+        let diagnostics = super::validate(&tree, self.glyph_map);
+        print_warnings_return_errors(diagnostics, &tree, self.verbose)
+            .map_err(CompilerError::ValidationFail)?;
+        let mut ctx = super::CompilationCtx::new(self.glyph_map, tree.source_map());
+        ctx.compile(&tree.typed_root());
+
+        // we 'take' the errors here because it's easier for us to handle the
+        // warnings using our helper method.
+        print_warnings_return_errors(std::mem::take(&mut ctx.errors), &tree, self.verbose)
+            .map_err(CompilerError::CompilationFail)?;
+        Ok(ctx.build().unwrap()) // we've taken the errors, so this can't fail
+    }
+}
+
+fn print_warnings_return_errors(
+    mut diagnostics: Vec<Diagnostic>,
+    tree: &ParseTree,
+    verbose: bool,
+) -> Result<(), DiagnosticSet> {
+    diagnostics.sort_unstable_by_key(|diag| diag.level);
+    let split_at = diagnostics
+        .iter()
+        .position(|x| !x.is_error())
+        .unwrap_or(diagnostics.len());
+    let warnings = diagnostics.split_off(split_at);
+    if verbose {
+        for w in warnings {
+            eprintln!("{}", tree.format_diagnostic(&w));
+        }
+    }
+    if diagnostics.is_empty() {
+        Ok(())
+    } else {
+        Err(DiagnosticSet {
+            messages: diagnostics,
+            tree: tree.clone(),
+        })
+    }
+}

--- a/fea-rs/src/compile/error.rs
+++ b/fea-rs/src/compile/error.rs
@@ -1,6 +1,6 @@
 //! Error types related to compilation
 
-use write_fonts::read::ReadError;
+use write_fonts::{read::ReadError, validate::ValidationReport};
 
 use crate::{parse::SourceLoadError, Diagnostic, ParseTree};
 
@@ -43,7 +43,7 @@ pub enum GlyphOrderError {
 }
 
 /// An error reported by the compiler
-#[derive(Clone, Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
 pub enum CompilerError {
     #[error("{0}")]
@@ -58,7 +58,14 @@ pub enum CompilerError {
     ValidationFail(DiagnosticSet),
     #[error("Compilation failed with {} errors\n{0}", .0.messages.len())]
     CompilationFail(DiagnosticSet),
+    #[error("Binary generation failed: '{0}'")]
+    WriteFail(#[from] BinaryCompilationError),
 }
+
+/// An error that occured when generating the binary font
+#[derive(Debug, thiserror::Error)]
+#[error("Binary generation failed: '{0}'")]
+pub struct BinaryCompilationError(ValidationReport);
 
 /// A set of diagnostics with the associated source info
 #[derive(Clone)]
@@ -87,5 +94,11 @@ impl std::fmt::Debug for DiagnosticSet {
             .field("messages", &self.messages)
             .field("tree", &"ParseTree")
             .finish()
+    }
+}
+
+impl From<ValidationReport> for BinaryCompilationError {
+    fn from(src: ValidationReport) -> BinaryCompilationError {
+        BinaryCompilationError(src)
     }
 }

--- a/fea-rs/src/compile/error.rs
+++ b/fea-rs/src/compile/error.rs
@@ -2,6 +2,8 @@
 
 use write_fonts::read::ReadError;
 
+use crate::{parse::SourceLoadError, Diagnostic, ParseTree};
+
 /// An error that occurs when extracting a glyph order from a UFO.
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum UfoGlyphOrderError {
@@ -38,4 +40,52 @@ pub enum GlyphOrderError {
     /// Missing .notdef glyph
     #[error("The first glyph must be '.notdef'")]
     MissingNotDef,
+}
+
+/// An error reported by the compiler
+#[derive(Clone, Debug, thiserror::Error)]
+#[allow(missing_docs)]
+pub enum CompilerError {
+    #[error("{0}")]
+    SourceLoad(
+        #[from]
+        #[source]
+        SourceLoadError,
+    ),
+    #[error("Parsing failed with {} errors\n{0}", .0.messages.len())]
+    ParseFail(DiagnosticSet),
+    #[error("Validation failed with {} errors\n{0}", .0.messages.len())]
+    ValidationFail(DiagnosticSet),
+    #[error("Compilation failed with {} errors\n{0}", .0.messages.len())]
+    CompilationFail(DiagnosticSet),
+}
+
+/// A set of diagnostics with the associated source info
+#[derive(Clone)]
+pub struct DiagnosticSet {
+    pub(crate) messages: Vec<Diagnostic>,
+    pub(crate) tree: ParseTree,
+}
+
+impl std::fmt::Display for DiagnosticSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let mut first = true;
+        for err in &self.messages {
+            if !first {
+                writeln!(f)?;
+            }
+            write!(f, "{}", self.tree.format_diagnostic(err))?;
+            first = false;
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for DiagnosticSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DiagnosticSet")
+            .field("messages", &self.messages)
+            .field("tree", &"ParseTree")
+            .finish()
+    }
 }

--- a/fea-rs/src/diagnostic.rs
+++ b/fea-rs/src/diagnostic.rs
@@ -10,7 +10,8 @@ pub struct Span {
 }
 
 /// A diagnostic level
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
 pub enum Level {
     /// An unrecoverable error
     Error,

--- a/fea-rs/src/lib.rs
+++ b/fea-rs/src/lib.rs
@@ -1,4 +1,7 @@
 //! Parsing and compiling the Adobe OpenType Feature File format.
+//!
+//! The main entry point for this crate is the [`Compiler`] struct, which provides
+//! a builder-like interface for compiliing from source.
 
 #![deny(missing_docs)]
 

--- a/fea-rs/src/lib.rs
+++ b/fea-rs/src/lib.rs
@@ -13,7 +13,7 @@ pub mod util;
 mod tests;
 
 pub use common::{GlyphIdent, GlyphMap, GlyphName};
-pub use compile::Compilation;
+pub use compile::Compiler;
 pub use diagnostic::{Diagnostic, Level};
 pub use parse::{ParseTree, TokenSet};
 pub use token_tree::{typed, Kind, Node, NodeOrToken, Token};

--- a/fea-rs/src/parse.rs
+++ b/fea-rs/src/parse.rs
@@ -10,7 +10,7 @@ mod parser;
 mod source;
 mod tree;
 
-use std::{ffi::OsString, path::PathBuf, rc::Rc};
+use std::{ffi::OsString, path::PathBuf, sync::Arc};
 
 pub use lexer::TokenSet;
 pub use source::{FileSystemResolver, SourceLoadError, SourceResolver};
@@ -74,8 +74,8 @@ pub fn parse_root(
 /// This is useful for things like testing or syntax highlighting of a single file,
 /// but it cannot handle imports, or handle ambiguous glyph names.
 ///
-/// The input text can be any of `&str`, `String`, or `Rc<str>`.
-pub fn parse_string(text: impl Into<Rc<str>>) -> (Node, Vec<Diagnostic>) {
+/// The input text can be any of `&str`, `String`, or `Arc<str>`.
+pub fn parse_string(text: impl Into<Arc<str>>) -> (Node, Vec<Diagnostic>) {
     let source = source::Source::new("<parse::parse_string>", text.into());
     let (node, errs, _) = context::parse_src(&source, None);
     (node, errs)

--- a/fea-rs/src/parse.rs
+++ b/fea-rs/src/parse.rs
@@ -65,7 +65,8 @@ pub fn parse_root(
     glyph_map: Option<&GlyphMap>,
     resolver: impl SourceResolver + 'static,
 ) -> Result<(ParseTree, Vec<Diagnostic>), SourceLoadError> {
-    context::ParseContext::parse(path, glyph_map, resolver).map(|ctx| ctx.generate_parse_tree())
+    context::ParseContext::parse(path, glyph_map, Box::new(resolver))
+        .map(|ctx| ctx.generate_parse_tree())
 }
 
 /// Convenience method to parse a block of FEA from memory.

--- a/fea-rs/src/parse.rs
+++ b/fea-rs/src/parse.rs
@@ -13,10 +13,10 @@ mod tree;
 use std::{ffi::OsString, path::PathBuf, rc::Rc};
 
 pub use lexer::TokenSet;
-pub use source::{SourceLoadError, SourceResolver};
+pub use source::{FileSystemResolver, SourceLoadError, SourceResolver};
 pub use tree::ParseTree;
 
-pub(crate) use context::IncludeStatement;
+pub(crate) use context::{IncludeStatement, ParseContext};
 pub(crate) use parser::Parser;
 pub(crate) use source::{FileId, Source, SourceList, SourceMap};
 

--- a/fea-rs/src/parse/context.rs
+++ b/fea-rs/src/parse/context.rs
@@ -376,8 +376,8 @@ mod tests {
             "a".into(),
             None,
             Box::new(|path: &OsStr| match path.to_str().unwrap() {
-                "a" => Ok("include(bb);".to_owned()),
-                "bb" => Ok("include(a);".to_owned()),
+                "a" => Ok("include(bb);".into()),
+                "bb" => Ok("include(a);".into()),
                 _ => Err(SourceLoadError::new(
                     path.to_owned(),
                     std::io::Error::new(std::io::ErrorKind::NotFound, "oh no"),
@@ -406,9 +406,9 @@ mod tests {
             "file_a".into(),
             None,
             Box::new(|path: &OsStr| match path.to_str().unwrap() {
-                "file_a" => Ok(file_a.to_string()),
-                "b" => Ok(file_b.to_string()),
-                "c" => Ok(file_c.to_string()),
+                "file_a" => Ok(file_a.into()),
+                "b" => Ok(file_b.into()),
+                "c" => Ok(file_c.into()),
                 _ => Err(SourceLoadError::new(
                     path.into(),
                     std::io::Error::new(std::io::ErrorKind::NotFound, "oh no"),

--- a/fea-rs/src/parse/context.rs
+++ b/fea-rs/src/parse/context.rs
@@ -417,9 +417,9 @@ mod tests {
         )
         .unwrap();
 
-        let a_id = parse.sources.id_for_path(&"file_a").unwrap();
-        let b_id = parse.sources.id_for_path(&"b").unwrap();
-        let c_id = parse.sources.id_for_path(&"c").unwrap();
+        let a_id = parse.sources.id_for_path("file_a").unwrap();
+        let b_id = parse.sources.id_for_path("b").unwrap();
+        let c_id = parse.sources.id_for_path("c").unwrap();
 
         let (resolved, errs) = parse.generate_parse_tree();
         assert!(errs.is_empty(), "{errs:?}");

--- a/fea-rs/src/parse/context.rs
+++ b/fea-rs/src/parse/context.rs
@@ -4,7 +4,7 @@ use std::{
     collections::{HashMap, HashSet},
     ffi::OsString,
     ops::Range,
-    rc::Rc,
+    sync::Arc,
 };
 
 use super::source::{Source, SourceLoadError, SourceLoader, SourceResolver};
@@ -55,7 +55,7 @@ const MAX_INCLUDE_DEPTH: usize = 50;
 #[derive(Debug)]
 pub(crate) struct ParseContext {
     root_id: FileId,
-    sources: Rc<SourceList>,
+    sources: Arc<SourceList>,
     parsed_files: HashMap<FileId, (Node, Vec<Diagnostic>)>,
     graph: IncludeGraph,
 }
@@ -203,7 +203,7 @@ impl ParseContext {
         (
             ParseTree {
                 root,
-                map: Rc::new(map),
+                map: Arc::new(map),
                 sources: self.sources,
             },
             all_errors,

--- a/fea-rs/src/parse/source.rs
+++ b/fea-rs/src/parse/source.rs
@@ -98,6 +98,7 @@ pub trait SourceResolver {
     }
 
     /// A convenience method for creating a `Source` after loading a path.
+    #[doc(hidden)]
     fn resolve(&self, path: &OsStr) -> Result<Source, SourceLoadError> {
         let contents = self.get_contents(path)?;
         Ok(Source::new(path.to_owned(), contents.into()))
@@ -196,7 +197,7 @@ impl Source {
         &self.path
     }
 
-    /// The [`FileId`] for this source.
+    /// The `FileId` for this source.
     pub fn id(&self) -> FileId {
         self.id
     }

--- a/fea-rs/src/parse/tree.rs
+++ b/fea-rs/src/parse/tree.rs
@@ -1,6 +1,6 @@
 //! the result of a parsing operation
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 use super::source::Source;
 use super::{FileId, SourceList, SourceMap};
@@ -16,8 +16,9 @@ use crate::{token_tree::typed, Diagnostic, Node};
 #[derive(Clone, Debug)]
 pub struct ParseTree {
     pub(crate) root: Node,
-    pub(crate) sources: Rc<SourceList>,
-    pub(crate) map: Rc<SourceMap>,
+    // Arc so we can send across threads
+    pub(crate) sources: Arc<SourceList>,
+    pub(crate) map: Arc<SourceMap>,
 }
 
 impl ParseTree {

--- a/fea-rs/src/parse/tree.rs
+++ b/fea-rs/src/parse/tree.rs
@@ -1,14 +1,23 @@
 //! the result of a parsing operation
 
+use std::rc::Rc;
+
 use super::source::Source;
 use super::{FileId, SourceList, SourceMap};
 use crate::{token_tree::typed, Diagnostic, Node};
 
 /// A fully parsed feature file, with attached imports and a sourcemap.
+///
+/// As well as representing the entire AST, this type also allows mapping tokens
+/// and other spans back to a position in a particular source file.
+///
+/// This is cheap to clone, so it can be attached to diagnostics, allowing them
+/// to print themselves where needed.
+#[derive(Clone, Debug)]
 pub struct ParseTree {
     pub(crate) root: Node,
-    pub(crate) sources: SourceList,
-    pub(crate) map: SourceMap,
+    pub(crate) sources: Rc<SourceList>,
+    pub(crate) map: Rc<SourceMap>,
 }
 
 impl ParseTree {

--- a/fea-rs/src/util/paths.rs
+++ b/fea-rs/src/util/paths.rs
@@ -51,6 +51,11 @@ fn rebase_path(path: &Path, base: &Path) -> PathBuf {
 ///
 /// [the spec]: http://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#3-including-files
 pub(crate) fn resolve_path(path: &Path, root: &Path, parent: Option<&Path>) -> PathBuf {
+    if path.is_absolute() {
+        log::info!("path {} is absolute", path.display());
+        return path.to_path_buf();
+    }
+
     if root.join(path).exists() {
         return rebase_path(path, root);
     }


### PR DESCRIPTION
This introduces a new builder-style API that can handle the entire compilation process.

Basic usage looks like,

```rust
let my_font_bytes = Compiler::new("path/to/features.fea", &glyph_map).compile_binary().unwrap();
```

Getting this to work well required reworking our error types, and doing that motivated a refactor to make `ParseTree` cheaply cloneable; doing this means that we can have an error type that contains some set of `Diagnostic` messages along with the `ParseTree` required to format them correctly.

I imagine we will run into some rough edges on this over time, but I hope this is at least the general outline of our API going forward.