### PR TITLE
Make CompilerError: Send

### DIFF
--- a/fea-rs/src/compile/compiler.rs
+++ b/fea-rs/src/compile/compiler.rs
@@ -151,7 +151,7 @@ fn print_warnings_return_errors(
     } else {
         Err(DiagnosticSet {
             messages: diagnostics,
-            tree: tree.clone(),
+            sources: tree.sources.clone(),
         })
     }
 }

--- a/fea-rs/src/parse/tree.rs
+++ b/fea-rs/src/parse/tree.rs
@@ -47,9 +47,6 @@ impl ParseTree {
     /// This associates the message with the appropriate source location and
     /// syntax highlighting.
     pub fn format_diagnostic(&self, err: &Diagnostic) -> String {
-        let mut s = String::new();
-        let source = self.get_source(err.message.file).unwrap();
-        crate::util::highlighting::write_diagnostic(&mut s, err, source, None);
-        s
+        self.sources.format_diagnostic(err)
     }
 }

--- a/fea-rs/src/util/ttx.rs
+++ b/fea-rs/src/util/ttx.rs
@@ -245,7 +245,7 @@ pub fn run_test(path: PathBuf, glyph_map: &GlyphMap) -> Result<PathBuf, TestCase
 /// Convert diagnostics to a printable string
 pub fn stringify_diagnostics(root: &ParseTree, diagnostics: &[Diagnostic]) -> String {
     DiagnosticSet {
-        tree: root.to_owned(),
+        sources: root.sources.clone(),
         messages: diagnostics.to_owned(),
     }
     .to_string()


### PR DESCRIPTION
This was a bit interesting. In order to make this work,
- I changed SourceLoadError to not store the inner error, since Arc<T> is only Send if T: Sync, and then we run into the problem where we can't create a SourceLoadError with a non-Sync inner error; so now we just store a message as an Arc<str>.
- I also changed the DiagnosticSet type to not store the whole parse tree, but just the source list, which is apparently all we actually need to format our errors.
- yolo