### PR TITLE
Update fontations to 0.1.0 and update fea-rs to 0.3.0 to unblock fontmake-rs

### DIFF
--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fea-rs"
-version = "0.2.0"
+version = "0.2.1"
 license = "MIT/Apache-2.0"
 authors = ["Colin Rofls <colin@cmyr.net>"]
 description = "Tools for working with Adobe OpenType Feature files."
@@ -16,7 +16,7 @@ exclude = ["test-data"]
 ansi_term = "0.12.1"
 smol_str = "0.1.18"
 norad = "0.8" # just for use in sample binaries/debugging, remove eventually
-write-fonts = { version = "0.0.5" }
+write-fonts = { version = "0.0.6" }
 chrono = "0.4.3"
 diff = { version = "0.1.12", optional = true }
 rayon = { version = "1.6", optional = true }

--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fea-rs"
-version = "0.2.1"
+version = "0.3.0"
 license = "MIT/Apache-2.0"
 authors = ["Colin Rofls <colin@cmyr.net>"]
 description = "Tools for working with Adobe OpenType Feature files."
@@ -16,7 +16,7 @@ exclude = ["test-data"]
 ansi_term = "0.12.1"
 smol_str = "0.1.18"
 norad = "0.8" # just for use in sample binaries/debugging, remove eventually
-write-fonts = { version = "0.0.6" }
+write-fonts = { version = "0.1.0" }
 chrono = "0.4.3"
 diff = { version = "0.1.12", optional = true }
 rayon = { version = "1.6", optional = true }


### PR DESCRIPTION
Unblocks https://github.com/googlefonts/fontmake-rs/pull/123 which is currently stuck on 

mismatched types
struct write_fonts::font_builder::FontBuilder and struct FontBuilder have similar names, but are actually distinct types
perhaps two different versions of crate write_fonts are being used?rustcClick for full compiler diagnostic

Because fea-rs is on 0.0.5, the rest of fontmake-rs is on 0.0.6, and that's a compile error.

Also ... I seem to own fea-rs on [crates.io](http://crates.io/) but not have write access to the repo. Should I? Or should we make a copy under googlefonts?
