### PR TITLE
[WIP] Move to write-fonts 0.2.0 which makes FontBuilder::build fallible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[patch.crates-io]
+write-fonts = { git="https://github.com/googlefonts/fontations.git", branch="ots" }
+
 [workspace]
 members = [
     "fea-rs",

--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["test-data"]
 ansi_term = "0.12.1"
 smol_str = "0.1.18"
 norad = "0.8" # just for use in sample binaries/debugging, remove eventually
-write-fonts = { version = "0.1.5" }
+write-fonts = { version = "0.2.0" }
 chrono = "0.4.3"
 diff = { version = "0.1.12", optional = true }
 rayon = { version = "1.6", optional = true }

--- a/fea-rs/src/bin/compile.rs
+++ b/fea-rs/src/bin/compile.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 use fea_rs::{
     compile::{
         self,
-        error::{FontGlyphOrderError, GlyphOrderError, UfoGlyphOrderError},
+        error::{CompilerError, FontGlyphOrderError, GlyphOrderError, UfoGlyphOrderError},
         Compiler, Opts,
     },
     GlyphMap,
@@ -33,7 +33,8 @@ fn main() -> Result<(), Error> {
     let raw_font = compiled
         .assemble(&glyph_names, opts)
         .expect("ttf compile failed")
-        .build();
+        .build()
+        .map_err(CompilerError::FontBuildFailed)?;
 
     log::info!("writing {} bytes to {}", raw_font.len(), path.display());
     std::fs::write(path, raw_font).map_err(Into::into)

--- a/fea-rs/src/compile/compiler.rs
+++ b/fea-rs/src/compile/compiler.rs
@@ -126,7 +126,10 @@ impl<'a> Compiler<'a> {
     pub fn compile_binary(self) -> Result<Vec<u8>, CompilerError> {
         let opts = self.opts.clone();
         let glyph_map = self.glyph_map;
-        Ok(self.compile()?.assemble(glyph_map, opts)?.build())
+        self.compile()?
+            .assemble(glyph_map, opts)?
+            .build()
+            .map_err(CompilerError::FontBuildFailed)
     }
 }
 

--- a/fea-rs/src/compile/error.rs
+++ b/fea-rs/src/compile/error.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use write_fonts::{read::ReadError, validate::ValidationReport};
+use write_fonts::{read::ReadError, validate::ValidationReport, BuildFontError};
 
 use crate::{
     parse::{SourceList, SourceLoadError},
@@ -65,6 +65,8 @@ pub enum CompilerError {
     CompilationFail(DiagnosticSet),
     #[error("Binary generation failed: '{0}'")]
     WriteFail(#[from] BinaryCompilationError),
+    #[error("Font generation failed: '{0:?}'")]
+    FontBuildFailed(BuildFontError),
 }
 
 /// An error that occured when generating the binary font


### PR DESCRIPTION
DO NOT MERGE yet as write-fonts 0.2.0 (https://github.com/googlefonts/fontations/pull/322) is not yet published. 