### PR TITLE
bump write-fonts to 0.2.0

### DIFF
--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["test-data"]
 ansi_term = "0.12.1"
 smol_str = "0.1.18"
 norad = "0.8" # just for use in sample binaries/debugging, remove eventually
-write-fonts = { version = "0.1.5" }
+write-fonts = { version = "0.2.0" }
 chrono = "0.4.3"
 diff = { version = "0.1.12", optional = true }
 rayon = { version = "1.6", optional = true }


### PR DESCRIPTION
unblocks broken build when bumping write-fonts in fontmake-rs (which in turn depends on fea-rs), see https://github.com/googlefonts/fontmake-rs/pull/277