### PR TITLE
Improve diff printing

### DIFF
--- a/fea-rs/src/util/pretty_diff.rs
+++ b/fea-rs/src/util/pretty_diff.rs
@@ -60,8 +60,12 @@ impl std::fmt::Display for MyStrs<'_> {
 }
 
 /// Present the diff output for two mutliline strings in a pretty, colorised manner.
-pub fn write_line_diff<TWrite: fmt::Write>(f: &mut TWrite, left: &str, right: &str) -> fmt::Result {
-    let diff = ::diff::lines(left, right);
+pub fn write_line_diff<TWrite: fmt::Write>(
+    f: &mut TWrite,
+    expected: &str,
+    actual: &str,
+) -> fmt::Result {
+    let diff = ::diff::lines(expected, actual);
 
     let mut changes = diff.into_iter().peekable();
     let mut previous_deletion = LatentDeletion::default();

--- a/fea-rs/src/util/ttx.rs
+++ b/fea-rs/src/util/ttx.rs
@@ -729,7 +729,7 @@ impl Display for ReasonPrinter<'_> {
             } => {
                 if self.verbose {
                     writeln!(f, "compare failure")?;
-                    super::write_line_diff(f, result, expected)
+                    super::write_line_diff(f, expected, result)
                 } else {
                     write!(
                         f,


### PR DESCRIPTION
This documents which string is considered the 'base' when we generated a colored diff, and uses the 'expected' result as the base when printing test failures.