### PR TITLE
Support named value records (valueRecordDef)

### DIFF
--- a/fea-rs/src/compile/validate.rs
+++ b/fea-rs/src/compile/validate.rs
@@ -89,8 +89,8 @@ impl<'a> ValidationCtx<'a> {
                 self.validate_table(&table);
             } else if let Some(lookup) = typed::LookupBlock::cast(item) {
                 self.validate_lookup_block(&lookup, None);
-            } else if let Some(_value_record_def) = typed::ValueRecordDef::cast(item) {
-                unimplemented!("valueRecordDef")
+            } else if let Some(node) = typed::ValueRecordDef::cast(item) {
+                self.validate_value_record_def(&node);
             } else if item.kind() == Kind::AnonKw {
                 unimplemented!("anon")
             }
@@ -194,6 +194,18 @@ impl<'a> ValidationCtx<'a> {
         self.mark_class_defs
             .insert(node.mark_class_name().text().clone());
         self.validate_anchor(&node.anchor());
+    }
+
+    fn validate_value_record_def(&mut self, node: &typed::ValueRecordDef) {
+        let record = node.value_record();
+        self.validate_value_record(&record);
+        let name = node.name();
+        if let Some(_prev) = self
+            .value_record_defs
+            .insert(name.text.clone(), name.clone())
+        {
+            self.warning(name.range(), "duplicate value record name");
+        }
     }
 
     fn validate_mark_class(&mut self, node: &typed::GlyphClassName) {

--- a/fea-rs/src/token_tree/typed.rs
+++ b/fea-rs/src/token_tree/typed.rs
@@ -203,7 +203,7 @@ ast_node!(GlyphClassDef, Kind::GlyphClassDefNode);
 ast_node!(MarkClassDef, Kind::MarkClassNode);
 ast_node!(Anchor, Kind::AnchorNode);
 ast_node!(AnchorDef, Kind::AnchorDefNode);
-ast_node!(ValueRecordDef, Kind::ValueRecordDefKw);
+ast_node!(ValueRecordDef, Kind::ValueRecordDefNode);
 ast_node!(GlyphClassLiteral, Kind::GlyphClass);
 ast_node!(LanguageSystem, Kind::LanguageSystemNode);
 ast_node!(Include, Kind::IncludeNode);
@@ -520,6 +520,16 @@ impl MarkClassDef {
             .skip_while(|t| t.kind() != Kind::AnchorNode)
             .find_map(GlyphClassName::cast)
             .unwrap()
+    }
+}
+
+impl ValueRecordDef {
+    pub(crate) fn value_record(&self) -> ValueRecord {
+        self.iter().find_map(ValueRecord::cast).unwrap()
+    }
+
+    pub(crate) fn name(&self) -> &Token {
+        self.find_token(Kind::Ident).expect("validated")
     }
 }
 


### PR DESCRIPTION
We never got around to this because it isn't used much and it wasn't included in any of the feaLib test files that we were initially using, but it's part of the spec and is used in the latest feaLib tests.