### PR TITLE
Parse variable feature syntax

### DIFF
--- a/fea-lsp/src/document.rs
+++ b/fea-lsp/src/document.rs
@@ -187,7 +187,7 @@ pub static STYLES: &[SemanticTokenType] = &[
 fn style_for_kind(kind: Kind) -> Option<u32> {
     let raw = match kind {
         Kind::Comment => 2,
-        Kind::Number | Kind::Metric | Kind::Octal | Kind::Hex | Kind::Float => 1,
+        Kind::Number | Kind::Octal | Kind::Hex | Kind::Float => 1,
         Kind::String => 3,
 
         Kind::GlyphName | Kind::Cid => 10,

--- a/fea-rs/src/compile/validate.rs
+++ b/fea-rs/src/compile/validate.rs
@@ -233,12 +233,26 @@ impl<'a> ValidationCtx<'a> {
         //TODO: same number of records as there are number of baseline tags
     }
 
-    fn validate_hhea(&mut self, _node: &typed::HheaTable) {
-        // lgtm
+    fn validate_hhea(&mut self, node: &typed::HheaTable) {
+        self.ensure_metrics_are_non_variable(node.metrics());
     }
 
-    fn validate_vhea(&mut self, _node: &typed::VheaTable) {
-        // lgtm
+    fn validate_vhea(&mut self, node: &typed::VheaTable) {
+        self.ensure_metrics_are_non_variable(node.metrics());
+    }
+
+    fn ensure_metrics_are_non_variable(
+        &mut self,
+        metrics: impl Iterator<Item = typed::MetricRecord>,
+    ) {
+        for record in metrics {
+            if record.metric().parse_simple().is_none() {
+                self.error(
+                    record.metric().range(),
+                    "variable metrics not yet supported",
+                );
+            }
+        }
     }
 
     fn validate_vmtx(&mut self, node: &typed::VmtxTable) {
@@ -304,8 +318,14 @@ impl<'a> ValidationCtx<'a> {
                 typed::Os2TableItem::Metric(i) => {
                     if matches!(i.keyword().kind, Kind::WinAscentKw | Kind::WinDescentKw) {
                         let val = i.metric();
-                        if val.parse().is_negative() {
-                            self.error(val.range(), "expected positive number");
+                        match val.parse_simple() {
+                            None => {
+                                self.error(val.range(), "variable metrics not yet supports in OS/2")
+                            }
+                            Some(x) if x.is_negative() => {
+                                self.error(val.range(), "expected positive number")
+                            }
+                            Some(_) => (),
                         }
                     }
                 }

--- a/fea-rs/src/parse/grammar/feature.rs
+++ b/fea-rs/src/parse/grammar/feature.rs
@@ -72,7 +72,7 @@ pub(crate) fn lookup_block(parser: &mut Parser, recovery: TokenSet) {
 }
 
 /// returns true if we advanced the parser.
-fn statement(parser: &mut Parser, recovery: TokenSet, in_lookup: bool) -> bool {
+pub(crate) fn statement(parser: &mut Parser, recovery: TokenSet, in_lookup: bool) -> bool {
     let start_pos = parser.nth_range(0).start;
     match parser.nth(0).kind.to_token_kind() {
         Kind::PosKw | Kind::SubKw | Kind::RsubKw | Kind::IgnoreKw | Kind::EnumKw => {

--- a/fea-rs/src/parse/grammar/metrics.rs
+++ b/fea-rs/src/parse/grammar/metrics.rs
@@ -20,14 +20,12 @@ pub(crate) fn anchor(parser: &mut Parser, recovery: TokenSet) -> bool {
             return parser.expect_recover(Kind::RAngle, recovery);
         }
 
-        const RANGLE: TokenSet = TokenSet::new(&[Kind::RAngle]);
-        let recovery = recovery.union(RANGLE);
+        let recovery = recovery.add(Kind::RAngle).add(Kind::ContourpointKw);
         // now either:
         // <metric> metric>
         // <metric> <metric> <contour point>
         // <metric> <metric> <device> <device>
-        parser.expect_remap_recover(Kind::Number, AstKind::Metric, recovery);
-        parser.expect_remap_recover(Kind::Number, AstKind::Metric, recovery);
+        parser.repeat(|parser| expect_metric(parser, recovery), 2);
         if parser.eat(Kind::ContourpointKw) {
             parser.expect_recover(Kind::Number, recovery);
         } else if eat_device(parser, recovery) {
@@ -39,6 +37,15 @@ pub(crate) fn anchor(parser: &mut Parser, recovery: TokenSet) -> bool {
     parser.in_node(AstKind::AnchorNode, |parser| anchor_body(parser, recovery))
 }
 
+pub(crate) fn expect_value_record(parser: &mut Parser, recovery: TokenSet) -> bool {
+    if eat_value_record(parser, recovery) {
+        true
+    } else {
+        parser.err_recover("expected valuerecord", recovery);
+        false
+    }
+}
+
 // A: <metric> (-5)
 // B: <<metric> <metric> <metric> <metric>> (<1 2 -5 242>)
 // C: <<metric> <metric> <metric> <metric> <device> <device> <device> <device>>
@@ -46,7 +53,7 @@ pub(crate) fn anchor(parser: &mut Parser, recovery: TokenSet) -> bool {
 // return 'true' if we make any progress (this looks like a value record)
 pub(crate) fn eat_value_record(parser: &mut Parser, recovery: TokenSet) -> bool {
     fn value_record_body(parser: &mut Parser, recovery: TokenSet) {
-        if parser.eat(Kind::Number) {
+        if eat_metric(parser, recovery) {
             return;
         }
 
@@ -57,23 +64,16 @@ pub(crate) fn eat_value_record(parser: &mut Parser, recovery: TokenSet) -> bool 
             return;
         }
 
-        // we use && so we stop at the first failure
-        let _ = parser.expect_recover(Kind::Number, recovery)
-            && parser.expect_recover(Kind::Number, recovery)
-            && parser.expect_recover(Kind::Number, recovery)
-            && parser.expect_recover(Kind::Number, recovery);
+        parser.repeat(|parser| expect_metric(parser, recovery), 4);
         if parser.eat(Kind::RAngle) {
             return;
         }
         // type C:
-        let _ = expect_device(parser, recovery)
-            && expect_device(parser, recovery)
-            && expect_device(parser, recovery)
-            && expect_device(parser, recovery);
+        parser.repeat(|parser| expect_device(parser, recovery), 4);
         parser.expect_recover(Kind::RAngle, recovery);
     }
 
-    let looks_like_record = parser.matches(0, Kind::Number)
+    let looks_like_record = parser.matches(0, TokenSet::new(&[Kind::Number, Kind::LParen]))
         || (parser.matches(0, Kind::LAngle)
             && parser.matches(
                 1,
@@ -91,13 +91,78 @@ pub(crate) fn eat_value_record(parser: &mut Parser, recovery: TokenSet) -> bool 
     true
 }
 
-pub(crate) fn expect_value_record(parser: &mut Parser, recovery: TokenSet) -> bool {
-    if eat_value_record(parser, recovery) {
-        true
-    } else {
-        parser.err_recover("expected valuerecord", recovery);
-        false
+pub(crate) fn expect_metric(parser: &mut Parser, recovery: TokenSet) -> bool {
+    if !eat_metric(parser, recovery) {
+        parser.err_recover("expected metric (scalar or variable)", recovery);
+        return false;
     }
+    true
+}
+
+/// Eat a metric, which may either be a number or a variable metric.
+///
+/// A variable metric has the syntax `(<location_spec>:<number> +)`
+/// where a `<location_spec>` is,
+/// `<axis_tag>=<number>,+`
+fn eat_metric(parser: &mut Parser, recovery: TokenSet) -> bool {
+    // a simple numerical metric
+    if parser.eat(Kind::Number) {
+        return true;
+    // else we expect a variable metric; return if we dont' find a paren
+    } else if !parser.matches(0, Kind::LParen) {
+        return false;
+    }
+
+    parser.in_node(AstKind::VariableMetricNode, |parser| {
+        parser.eat_raw();
+        while !parser.at_eof() && !parser.matches(0, Kind::RParen) {
+            if !parser.in_node(AstKind::LocationValueNode, |parser| {
+                eat_variation_location_and_value(parser, recovery.add(Kind::RParen))
+            }) {
+                break;
+            }
+        }
+        parser.expect_recover(Kind::RParen, recovery)
+    });
+    true
+}
+
+fn eat_variation_location_and_value(parser: &mut Parser, recovery: TokenSet) -> bool {
+    parser.in_node(AstKind::LocationSpecNode, |parser| {
+        eat_location_spec(parser, recovery)
+    }) && parser.expect_recover(Kind::Colon, recovery)
+        && parser.expect_recover(Kind::Number, recovery)
+}
+
+fn eat_location_spec(parser: &mut Parser, recovery: TokenSet) -> bool {
+    if !expect_location_item(parser, recovery) {
+        return false;
+    }
+    while parser.eat(Kind::Comma) {
+        expect_location_item(parser, recovery);
+    }
+    true
+}
+
+fn expect_location_item(parser: &mut Parser, recovery: TokenSet) -> bool {
+    if !eat_location_item(parser, recovery) {
+        parser.err_recover("expected <tag>=<number>", recovery);
+        return false;
+    }
+    true
+}
+
+fn eat_location_item(parser: &mut Parser, recovery: TokenSet) -> bool {
+    if !parser.matches(0, TokenSet::TAG_LIKE) {
+        return false;
+    }
+
+    parser.in_node(AstKind::LocationSpecItemNode, |parser| {
+        parser.eat_tag();
+        parser.expect_recover(Kind::Eq, recovery.add(Kind::Comma));
+        parser.expect_recover(Kind::Number, recovery.add(Kind::Comma));
+    });
+    true
 }
 
 fn expect_device(parser: &mut Parser, recovery: TokenSet) -> bool {
@@ -118,16 +183,14 @@ fn eat_device(parser: &mut Parser, recovery: TokenSet) -> bool {
             return;
         }
 
-        parser.expect_recover(Kind::Number, recovery);
-        parser.expect_recover(Kind::Number, recovery);
+        parser.repeat(|parser| parser.expect_recover(Kind::Number, recovery), 2);
 
         while parser.eat(Kind::Comma) {
             // according to the spec <1 2,> should be legal?
             if parser.eat(Kind::RAngle) {
                 return;
             }
-            parser.expect_recover(Kind::Number, recovery);
-            parser.expect_recover(Kind::Number, recovery);
+            parser.repeat(|parser| parser.expect_recover(Kind::Number, recovery), 2);
         }
 
         // FIXME: this should handle an arbitary number of pairs? but also isn't
@@ -152,8 +215,10 @@ pub(crate) fn parameters(parser: &mut Parser, recovery: TokenSet) {
         parser.expect_recover(TokenSet::FLOAT_LIKE, recovery);
         parser.expect_recover(Kind::Number, recovery);
         if !parser.matches(0, Kind::Semi) {
-            parser.expect_recover(TokenSet::FLOAT_LIKE, recovery);
-            parser.expect_recover(TokenSet::FLOAT_LIKE, recovery);
+            parser.repeat(
+                |parser| parser.expect_recover(TokenSet::FLOAT_LIKE, recovery),
+                2,
+            );
         }
         parser.expect_semi();
     })
@@ -183,12 +248,21 @@ mod tests {
         let (_out, errors, _errstr) = debug_parse_output(fea, |parser| {
             anchor(parser, TokenSet::EMPTY);
         });
-        assert_eq!(errors.len(), 1);
+        assert_eq!(errors.len(), 1, "{_errstr}");
         assert!(
-            errors[0].text().contains("Expected METRIC"),
+            errors[0].text().contains("expected metric"),
             "{}",
             errors[0].text()
         );
+    }
+
+    #[test]
+    fn variable_anchor() {
+        let fea = "<anchor 0 (wght=200:-100 wght=900:-150 wght=900,wdth=150:-120)>";
+        let (_out, errors, _errstr) = debug_parse_output(fea, |parser| {
+            anchor(parser, TokenSet::EMPTY);
+        });
+        assert!(errors.is_empty());
     }
 
     #[test]

--- a/fea-rs/src/parse/grammar/mod.rs
+++ b/fea-rs/src/parse/grammar/mod.rs
@@ -8,6 +8,7 @@ mod gpos;
 mod gsub;
 mod metrics;
 mod table;
+mod variations;
 
 #[cfg(test)]
 // we use this in a test in edit.rs
@@ -47,6 +48,8 @@ fn top_level_element(parser: &mut Parser) {
         anonymous(parser)
     } else if parser.matches(0, Kind::NamedGlyphClass) {
         glyph::named_glyph_class_decl(parser, TokenSet::TOP_LEVEL)
+    } else if parser.matches(0, Kind::ConditionSetKw) {
+        variations::condition_set(parser)
     } else if parser.matches(0, Kind::ValueRecordDefKw) {
         value_record_def(parser, TokenSet::TOP_LEVEL)
     } else {

--- a/fea-rs/src/parse/grammar/mod.rs
+++ b/fea-rs/src/parse/grammar/mod.rs
@@ -194,8 +194,7 @@ fn anchor_def(parser: &mut Parser) {
             let recovery = TokenSet::TOP_LEVEL
                 .union(TokenSet::IDENT_LIKE)
                 .union(TokenSet::new(&[Kind::ContourpointKw, Kind::Semi]));
-            parser.expect_remap_recover(Kind::Number, AstKind::Metric, recovery);
-            parser.expect_remap_recover(Kind::Number, AstKind::Metric, recovery);
+            parser.repeat(|parser| metrics::expect_metric(parser, recovery), 2);
             if parser.eat(Kind::ContourpointKw) {
                 parser.expect_recover(Kind::Number, TokenSet::TOP_SEMI);
             }
@@ -362,7 +361,10 @@ mod tests {
         let out = typed::Root::cast(&out).unwrap();
         let value_def = out.iter().find_map(typed::ValueRecordDef::cast).unwrap();
         assert_eq!(
-            value_def.value_record().advance().map(|x| x.parse_signed()),
+            value_def
+                .value_record()
+                .advance()
+                .and_then(|x| x.parse_simple()),
             Some(123)
         );
         assert_eq!(value_def.name().as_str(), "foo");

--- a/fea-rs/src/parse/grammar/mod.rs
+++ b/fea-rs/src/parse/grammar/mod.rs
@@ -50,6 +50,8 @@ fn top_level_element(parser: &mut Parser) {
         glyph::named_glyph_class_decl(parser, TokenSet::TOP_LEVEL)
     } else if parser.matches(0, Kind::ConditionSetKw) {
         variations::condition_set(parser)
+    } else if parser.matches(0, Kind::VariationKw) {
+        variations::variation(parser)
     } else if parser.matches(0, Kind::ValueRecordDefKw) {
         value_record_def(parser, TokenSet::TOP_LEVEL)
     } else {

--- a/fea-rs/src/parse/grammar/table.rs
+++ b/fea-rs/src/parse/grammar/table.rs
@@ -269,11 +269,7 @@ mod hhea {
         if parser.matches(0, HHEA_KEYWORDS) {
             parser.in_node(AstKind::MetricValueNode, |parser| {
                 assert!(parser.eat(HHEA_KEYWORDS));
-                parser.expect_remap_recover(
-                    Kind::Number,
-                    AstKind::Metric,
-                    recovery.union(TokenSet::SEMI_RBRACE),
-                );
+                super::super::metrics::expect_metric(parser, recovery.union(TokenSet::SEMI_RBRACE));
                 parser.expect_recover(Kind::Semi, recovery.add(Kind::RBrace));
             })
         } else {
@@ -340,7 +336,7 @@ mod os2 {
         if parser.matches(0, METRICS) {
             parser.in_node(AstKind::MetricValueNode, |parser| {
                 assert!(parser.eat(METRICS));
-                parser.expect_remap_recover(Kind::Number, AstKind::Metric, recovery_semi);
+                super::super::metrics::expect_metric(parser, recovery);
                 parser.expect_semi();
             })
         } else if parser.matches(0, NUM_LISTS) {
@@ -389,7 +385,7 @@ mod vhea {
         if parser.matches(0, VHEA_KEYWORDS) {
             parser.in_node(AstKind::MetricValueNode, |parser| {
                 assert!(parser.eat(VHEA_KEYWORDS));
-                parser.expect_remap_recover(Kind::Number, AstKind::Metric, recovery_semi);
+                super::super::metrics::expect_metric(parser, recovery_semi);
                 parser.expect_semi();
             })
         } else {

--- a/fea-rs/src/parse/grammar/variations.rs
+++ b/fea-rs/src/parse/grammar/variations.rs
@@ -1,0 +1,62 @@
+//! syntax for variation syntax.
+//!
+//! See <https://github.com/adobe-type-tools/afdko/pull/1350>
+
+use crate::parse::{
+    lexer::{Kind, TokenSet},
+    Parser,
+};
+use crate::token_tree::Kind as AstKind;
+
+pub(crate) fn condition_set(parser: &mut Parser) {
+    // parse a single condition. returns true if we advance the cursor
+    // a condition looks like:
+    // <tag> <min> <max>;, e.g.
+    // wght 100 300;
+    fn condition(parser: &mut Parser) -> bool {
+        if !parser.matches(0, TokenSet::TAG_LIKE) {
+            return false;
+        }
+        parser.in_node(AstKind::ConditionNode, |parser| {
+            parser.eat_raw();
+            parser.expect_recover(Kind::Number, TokenSet::TOP_SEMI);
+            parser.expect_recover(Kind::Number, TokenSet::TOP_SEMI);
+            parser.expect_semi();
+        });
+
+        true
+    }
+
+    fn condition_set_body(parser: &mut Parser) {
+        assert!(parser.eat(Kind::ConditionSetKw));
+        // saved for error reporting
+        let raw_label_range = parser.matches(0, Kind::Ident).then(|| parser.nth_range(0));
+        parser.expect_remap_recover(
+            TokenSet::IDENT_LIKE,
+            AstKind::Label,
+            TokenSet::TOP_LEVEL.add(Kind::LBrace),
+        );
+        parser.expect(Kind::LBrace);
+        while !parser.at_eof() && !parser.matches(0, Kind::RBrace) {
+            if !condition(parser) {
+                if let Some(range) = raw_label_range {
+                    parser.raw_error(range, "Table is unclosed");
+                }
+                break;
+            }
+        }
+        parser.expect_recover(
+            Kind::RBrace,
+            TokenSet::TOP_LEVEL.union(TokenSet::IDENT_LIKE.union(TokenSet::SEMI)),
+        );
+        parser.expect_remap_recover(
+            TokenSet::IDENT_LIKE,
+            AstKind::Label,
+            TokenSet::TOP_LEVEL.union(TokenSet::SEMI),
+        );
+
+        parser.expect_semi();
+    }
+
+    parser.in_node(AstKind::ConditionSetNode, condition_set_body);
+}

--- a/fea-rs/src/parse/lexer/lexeme.rs
+++ b/fea-rs/src/parse/lexer/lexeme.rs
@@ -39,6 +39,7 @@ pub enum Kind {
 
     // special symbols
     Semi,
+    Colon,
     Comma,
     Backslash,
     Hyphen,
@@ -294,6 +295,7 @@ impl Kind {
             Self::Float => AstKind::Float,
             Self::Whitespace => AstKind::Whitespace,
             Self::Semi => AstKind::Semi,
+            Self::Colon => AstKind::Colon,
             Self::Comma => AstKind::Comma,
             Self::Backslash => AstKind::Backslash,
             Self::Hyphen => AstKind::Hyphen,
@@ -420,6 +422,7 @@ impl std::fmt::Display for Kind {
             Self::Float => write!(f, "FLOAT"),
             Self::Whitespace => write!(f, "WS"),
             Self::Semi => write!(f, ";"),
+            Self::Colon => write!(f, ":"),
             Self::Comma => write!(f, ","),
             Self::Backslash => write!(f, "\\"),
             Self::Hyphen => write!(f, "-"), // also minus

--- a/fea-rs/src/parse/lexer/lexeme.rs
+++ b/fea-rs/src/parse/lexer/lexeme.rs
@@ -65,6 +65,7 @@ pub enum Kind {
     MarkClassKw,
     AnonKw, // 'anon' and 'anonymous'
     ConditionSetKw,
+    VariationKw,
 
     // other keywords
     AnchorKw,
@@ -187,6 +188,7 @@ impl Kind {
             b"anchorDef" => Some(Kind::AnchorDefKw),
             b"anon" | b"anonymous" => Some(Kind::AnonKw),
             b"conditionset" => Some(Kind::ConditionSetKw),
+            b"variation" => Some(Kind::VariationKw),
             b"by" => Some(Kind::ByKw),
             b"contourpoint" => Some(Kind::ContourpointKw),
             b"cursive" => Some(Kind::CursiveKw),
@@ -317,6 +319,7 @@ impl Kind {
             Self::MarkClassKw => AstKind::MarkClassKw,
             Self::AnonKw => AstKind::AnonKw,
             Self::ConditionSetKw => AstKind::ConditionSetKw,
+            Self::VariationKw => AstKind::VariationKw,
             Self::AnchorKw => AstKind::AnchorKw,
             Self::ByKw => AstKind::ByKw,
             Self::ContourpointKw => AstKind::ContourpointKw,
@@ -445,6 +448,7 @@ impl std::fmt::Display for Kind {
             Self::AnonKw => write!(f, "AnonKw"),
             Self::AnchorKw => write!(f, "AnchorKw"),
             Self::ConditionSetKw => write!(f, "ConditionSetKw"),
+            Self::VariationKw => write!(f, "VariationKw"),
             Self::ByKw => write!(f, "ByKw"),
             Self::ContourpointKw => write!(f, "ContourpointKw"),
             Self::CursiveKw => write!(f, "CursiveKw"),

--- a/fea-rs/src/parse/lexer/lexeme.rs
+++ b/fea-rs/src/parse/lexer/lexeme.rs
@@ -16,7 +16,7 @@ impl Lexeme {
 
 /// Kinds of tokens assigned during lexing.
 ///
-/// These kinds are assigned by the lexer, and consumed by parser, which
+/// These kinds are assigned by the lexer, and consumed by the parser, which
 /// replaces them with the richer `Kind` enum in the `token_tree` module.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(u16)]
@@ -64,6 +64,7 @@ pub enum Kind {
     FeatureKw,
     MarkClassKw,
     AnonKw, // 'anon' and 'anonymous'
+    ConditionSetKw,
 
     // other keywords
     AnchorKw,
@@ -185,6 +186,7 @@ impl Kind {
             b"anchor" => Some(Kind::AnchorKw),
             b"anchorDef" => Some(Kind::AnchorDefKw),
             b"anon" | b"anonymous" => Some(Kind::AnonKw),
+            b"conditionset" => Some(Kind::ConditionSetKw),
             b"by" => Some(Kind::ByKw),
             b"contourpoint" => Some(Kind::ContourpointKw),
             b"cursive" => Some(Kind::CursiveKw),
@@ -314,6 +316,7 @@ impl Kind {
             Self::FeatureKw => AstKind::FeatureKw,
             Self::MarkClassKw => AstKind::MarkClassKw,
             Self::AnonKw => AstKind::AnonKw,
+            Self::ConditionSetKw => AstKind::ConditionSetKw,
             Self::AnchorKw => AstKind::AnchorKw,
             Self::ByKw => AstKind::ByKw,
             Self::ContourpointKw => AstKind::ContourpointKw,
@@ -441,6 +444,7 @@ impl std::fmt::Display for Kind {
             Self::MarkClassKw => write!(f, "MarkClassKw"),
             Self::AnonKw => write!(f, "AnonKw"),
             Self::AnchorKw => write!(f, "AnchorKw"),
+            Self::ConditionSetKw => write!(f, "ConditionSetKw"),
             Self::ByKw => write!(f, "ByKw"),
             Self::ContourpointKw => write!(f, "ContourpointKw"),
             Self::CursiveKw => write!(f, "CursiveKw"),

--- a/fea-rs/src/parse/lexer/token_set.rs
+++ b/fea-rs/src/parse/lexer/token_set.rs
@@ -133,7 +133,7 @@ impl TokenSet {
         TokenSet(self.0 | other.0)
     }
 
-    pub(crate) fn add(self, token: Kind) -> TokenSet {
+    pub(crate) const fn add(self, token: Kind) -> TokenSet {
         assert!((token as u16) < 128);
         TokenSet(self.0 | mask(token))
     }

--- a/fea-rs/src/token_tree/token.rs
+++ b/fea-rs/src/token_tree/token.rs
@@ -25,6 +25,7 @@ pub enum Kind {
 
     // special symbols
     Semi,
+    Colon,
     Comma,
     Backslash,
     Hyphen,
@@ -150,7 +151,7 @@ pub enum Kind {
 
     // not lexed
     GlyphRange,
-    Metric,
+    //Metric,
     Label,
     Tag,
     GlyphName,
@@ -229,6 +230,11 @@ pub enum Kind {
     ConditionSetNode,
     ConditionNode,
     VariationNode,
+
+    VariableMetricNode,
+    LocationValueNode,
+    LocationSpecNode,
+    LocationSpecItemNode,
 
     TableNode,
     HeadTableNode,
@@ -313,6 +319,7 @@ impl std::fmt::Display for Kind {
             Self::Float => write!(f, "FLOAT"),
             Self::Whitespace => write!(f, "WS"),
             Self::Semi => write!(f, ";"),
+            Self::Colon => write!(f, ":"),
             Self::Comma => write!(f, ","),
             Self::Backslash => write!(f, "\\"),
             Self::Hyphen => write!(f, "-"), // also minus
@@ -336,7 +343,7 @@ impl std::fmt::Display for Kind {
             Self::GlyphName => write!(f, "GlyphName"),
             Self::GlyphNameOrRange => write!(f, "GlyphNameOrRange"),
             Self::Cid => write!(f, "CID"),
-            Self::Metric => write!(f, "METRIC"),
+            //Self::Metric => write!(f, "METRIC"),
             Self::Label => write!(f, "LABEL"),
 
             Self::TableKw => write!(f, "TableKw"),
@@ -479,6 +486,11 @@ impl std::fmt::Display for Kind {
             Self::ConditionSetNode => write!(f, "ConditionSetNode"),
             Self::ConditionNode => write!(f, "ConditionNode"),
             Self::VariationNode => write!(f, "VariationNode"),
+            Self::VariableMetricNode => write!(f, "VariableMetricNode"),
+            Self::LocationValueNode => write!(f, "LocationValueNode"),
+            Self::LocationSpecNode => write!(f, "LocationSpecNode"),
+            Self::LocationSpecItemNode => write!(f, "LocationSpecItemNode"),
+
             Self::DeviceNode => write!(f, "DeviceNode"),
             Self::AnonBlockNode => write!(f, "AnonBlockNode"),
             Self::GlyphClassDefNode => write!(f, "GlyphClassDefNode"),
@@ -520,9 +532,9 @@ impl std::fmt::Display for Kind {
             Self::NameRecordNode => write!(f, "NameRecordNode"),
             Self::NameSpecNode => write!(f, "NameSpecNode"),
             Self::HeadFontRevisionNode => write!(f, "HeadFontRevisionNode"),
-            Self::MetricValueNode => write!(f, "MetricNode"), // shared between hhea, vhea, and os2
-            Self::NumberValueNode => write!(f, "NumberNode"), // used in os2
-            Self::StringValueNode => write!(f, "StringNode"), // used in os2
+            Self::MetricValueNode => write!(f, "MetricValueNode"), // shared between hhea, vhea, and os2
+            Self::NumberValueNode => write!(f, "NumberNode"),      // used in os2
+            Self::StringValueNode => write!(f, "StringNode"),      // used in os2
             Self::Os2NumberListNode => write!(f, "Os2NumberListNode"),
             Self::Os2FamilyClassNode => write!(f, "Os2FamilyClassNode"),
             Self::CvParamsNameNode => write!(f, "CvParamsNameNode"),

--- a/fea-rs/src/token_tree/token.rs
+++ b/fea-rs/src/token_tree/token.rs
@@ -1,4 +1,8 @@
 /// Kinds of tokens assigned during lexing and parsing.
+///
+/// This includes the set of raw tokens that are generated during lexing,
+/// but also includes richer information about the parsed FEA that is used to
+/// assign type information to collections of tokens ('nodes').
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[allow(missing_docs)]
 #[repr(u16)]
@@ -46,6 +50,7 @@ pub enum Kind {
     FeatureKw,
     MarkClassKw,
     AnonKw, // 'anon' and 'anonymous'
+    ConditionSetKw,
 
     // other keywords
     AnchorKw,
@@ -220,6 +225,8 @@ pub enum Kind {
     LanguageNode,
     LookupFlagNode,
     SubtableNode,
+    ConditionSetNode,
+    ConditionNode,
 
     TableNode,
     HeadTableNode,
@@ -337,6 +344,7 @@ impl std::fmt::Display for Kind {
             Self::FeatureKw => write!(f, "FeatureKw"),
             Self::MarkClassKw => write!(f, "MarkClassKw"),
             Self::AnonKw => write!(f, "AnonKw"),
+            Self::ConditionSetKw => write!(f, "ConditionSetKw"),
             Self::AnchorKw => write!(f, "AnchorKw"),
             Self::ByKw => write!(f, "ByKw"),
             Self::ContourpointKw => write!(f, "ContourpointKw"),
@@ -465,6 +473,8 @@ impl std::fmt::Display for Kind {
             Self::MarkClassNode => write!(f, "MarkClassNode"),
             Self::AnchorDefNode => write!(f, "AnchorDefNode"),
             Self::AnchorNode => write!(f, "AnchorNode"),
+            Self::ConditionSetNode => write!(f, "ConditionSetNode"),
+            Self::ConditionNode => write!(f, "ConditionNode"),
             Self::DeviceNode => write!(f, "DeviceNode"),
             Self::AnonBlockNode => write!(f, "AnonBlockNode"),
             Self::GlyphClassDefNode => write!(f, "GlyphClassDefNode"),

--- a/fea-rs/src/token_tree/token.rs
+++ b/fea-rs/src/token_tree/token.rs
@@ -51,6 +51,7 @@ pub enum Kind {
     MarkClassKw,
     AnonKw, // 'anon' and 'anonymous'
     ConditionSetKw,
+    VariationKw,
 
     // other keywords
     AnchorKw,
@@ -227,6 +228,7 @@ pub enum Kind {
     SubtableNode,
     ConditionSetNode,
     ConditionNode,
+    VariationNode,
 
     TableNode,
     HeadTableNode,
@@ -345,6 +347,7 @@ impl std::fmt::Display for Kind {
             Self::MarkClassKw => write!(f, "MarkClassKw"),
             Self::AnonKw => write!(f, "AnonKw"),
             Self::ConditionSetKw => write!(f, "ConditionSetKw"),
+            Self::VariationKw => write!(f, "VariationKw"),
             Self::AnchorKw => write!(f, "AnchorKw"),
             Self::ByKw => write!(f, "ByKw"),
             Self::ContourpointKw => write!(f, "ContourpointKw"),
@@ -475,6 +478,7 @@ impl std::fmt::Display for Kind {
             Self::AnchorNode => write!(f, "AnchorNode"),
             Self::ConditionSetNode => write!(f, "ConditionSetNode"),
             Self::ConditionNode => write!(f, "ConditionNode"),
+            Self::VariationNode => write!(f, "VariationNode"),
             Self::DeviceNode => write!(f, "DeviceNode"),
             Self::AnonBlockNode => write!(f, "AnonBlockNode"),
             Self::GlyphClassDefNode => write!(f, "GlyphClassDefNode"),

--- a/fea-rs/src/util/highlighting.rs
+++ b/fea-rs/src/util/highlighting.rs
@@ -9,7 +9,7 @@ use ansi_term::{Colour, Style};
 pub fn style_for_kind(kind: Kind) -> Style {
     match kind {
         Kind::Comment => Style::new().fg(Colour::Yellow).dimmed(),
-        Kind::Number | Kind::Metric | Kind::Octal | Kind::Hex | Kind::Float | Kind::String => {
+        Kind::Number | Kind::Octal | Kind::Hex | Kind::Float | Kind::String => {
             Style::new().fg(Colour::Green)
         }
         Kind::Ident | Kind::Tag | Kind::Label => Style::new().fg(Colour::Purple),


### PR DESCRIPTION
This is a checkpoint; we can now parse the new syntax, but we do not compile anything. It's possible that some of this code will need to change as I dig into the compilation side, but I think it's worth getting this in and working from here.