### PR TITLE
Update to write-fonts 0.7, bump version to 0.7

### DIFF
--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fea-rs"
-version = "0.6.0"
+version = "0.7.0"
 license = "MIT/Apache-2.0"
 authors = ["Colin Rofls <colin@cmyr.net>"]
 description = "Tools for working with Adobe OpenType Feature files."
@@ -16,7 +16,7 @@ exclude = ["test-data"]
 ansi_term = "0.12.1"
 smol_str = "0.2.0"
 norad = "0.10" # Used in the compile binary
-write-fonts = { version = "0.6.0" }
+write-fonts = { version = "0.7.0" }
 chrono = "0.4.3"
 diff = { version = "0.1.12", optional = true }
 rayon = { version = "1.6", optional = true }

--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -1367,7 +1367,9 @@ impl<'a> CompilationCtx<'a> {
                     _ => unreachable!("checked at parse time"),
                 },
                 typed::Os2TableItem::Vendor(item) => {
-                    os2.ach_vend_id = Tag::new(item.value().text.trim_matches('"').as_bytes());
+                    os2.ach_vend_id =
+                        Tag::new_checked(item.value().text.trim_matches('"').as_bytes())
+                            .expect("validated");
                 }
                 typed::Os2TableItem::FamilyClass(item) => {
                     os2.s_family_class = item.value().parse().unwrap() as i16

--- a/fea-rs/src/compile/features.rs
+++ b/fea-rs/src/compile/features.rs
@@ -283,10 +283,10 @@ impl SpecialVerticalFeatureState {
 mod tests {
     use super::*;
 
-    const fn langsys(script: &str, lang: &str) -> LanguageSystem {
+    const fn langsys(script: &[u8; 4], lang: &[u8; 4]) -> LanguageSystem {
         LanguageSystem {
-            script: Tag::new(script.as_bytes()),
-            language: Tag::new(lang.as_bytes()),
+            script: Tag::new(script),
+            language: Tag::new(lang),
         }
     }
 
@@ -305,11 +305,11 @@ mod tests {
         out
     }
 
-    const DFLT_DFLT: LanguageSystem = langsys("DFLT", "dflt");
-    const LATN_DFLT: LanguageSystem = langsys("latn", "dflt");
-    const LATN_DEU: LanguageSystem = langsys("latn", "DEU");
-    const LATN_TRK: LanguageSystem = langsys("latn", "TRK");
-    const LATN_POL: LanguageSystem = langsys("latn", "POL");
+    const DFLT_DFLT: LanguageSystem = langsys(b"DFLT", b"dflt");
+    const LATN_DFLT: LanguageSystem = langsys(b"latn", b"dflt");
+    const LATN_DEU: LanguageSystem = langsys(b"latn", b"DEU ");
+    const LATN_TRK: LanguageSystem = langsys(b"latn", b"TRK ");
+    const LATN_POL: LanguageSystem = langsys(b"latn", b"POL ");
     const TAG_TEST: Tag = Tag::new(b"test");
 
     #[test]
@@ -341,11 +341,11 @@ mod tests {
         assert_eq!(built.get(&key), Some(&vec![id_1, id_2]));
     }
 
-    const DFLT_FRE: LanguageSystem = langsys("DFLT", "FRE");
-    const DFLT_ABC: LanguageSystem = langsys("DFLT", "ABC");
-    const LATN_ABC: LanguageSystem = langsys("latn", "ABC");
-    const LATN_FRE: LanguageSystem = langsys("latn", "FRE");
-    const LATN_DEF: LanguageSystem = langsys("latn", "DEF");
+    const DFLT_FRE: LanguageSystem = langsys(b"DFLT", b"FRE ");
+    const DFLT_ABC: LanguageSystem = langsys(b"DFLT", b"ABC ");
+    const LATN_ABC: LanguageSystem = langsys(b"latn", b"ABC ");
+    const LATN_FRE: LanguageSystem = langsys(b"latn", b"FRE ");
+    const LATN_DEF: LanguageSystem = langsys(b"latn", b"DEF ");
 
     // <https://github.com/fonttools/fonttools/pull/1307>
     #[test]

--- a/fea-rs/src/compile/tags.rs
+++ b/fea-rs/src/compile/tags.rs
@@ -46,7 +46,6 @@ mod tests {
         assert!(is_stylistic_set(Tag::new(b"ss19")));
         assert!(!is_stylistic_set(Tag::new(b"ss00")));
         assert!(!is_stylistic_set(Tag::new(b"ss21")));
-        assert!(!is_stylistic_set(Tag::new(b"ss1")));
         assert!(!is_stylistic_set(Tag::new(b"ss1 ")));
         assert!(!is_stylistic_set(Tag::new(b"ss0f")));
     }
@@ -59,7 +58,6 @@ mod tests {
         assert!(is_character_variant(Tag::new(b"cv19")));
         assert!(is_character_variant(Tag::new(b"cv99")));
         assert!(!is_character_variant(Tag::new(b"cv00")));
-        assert!(!is_character_variant(Tag::new(b"cv1")));
         assert!(!is_character_variant(Tag::new(b"cv1 ")));
         assert!(!is_character_variant(Tag::new(b"cv9f")));
     }


### PR DESCRIPTION
This changed the API for constructing a tag, so I had to make some changes to accomodate that.