### PR TITLE
Fixup parsing of OS/2 vendor tag

### DIFF
--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -1367,9 +1367,7 @@ impl<'a> CompilationCtx<'a> {
                     _ => unreachable!("checked at parse time"),
                 },
                 typed::Os2TableItem::Vendor(item) => {
-                    os2.ach_vend_id =
-                        Tag::new_checked(item.value().text.trim_matches('"').as_bytes())
-                            .expect("validated");
+                    os2.ach_vend_id = item.parse_tag().expect("validated");
                 }
                 typed::Os2TableItem::FamilyClass(item) => {
                     os2.s_family_class = item.value().parse().unwrap() as i16

--- a/fea-rs/src/compile/validate.rs
+++ b/fea-rs/src/compile/validate.rs
@@ -7,7 +7,6 @@
 use std::{
     collections::{HashMap, HashSet},
     ops::Range,
-    str::FromStr,
 };
 
 use smol_str::SmolStr;
@@ -316,9 +315,8 @@ impl<'a> ValidationCtx<'a> {
                     }
                 }
                 typed::Os2TableItem::Vendor(item) => {
-                    let val = item.value();
-                    if let Err(e) = Tag::from_str(val.as_str().trim_matches('"')) {
-                        self.error(val.range(), format!("invalid tag: '{}'", e));
+                    if let Err(e) = item.parse_tag() {
+                        self.error(item.value().range(), format!("invalid tag: '{}'", e));
                     }
                 }
             }

--- a/fea-rs/src/token_tree/typed.rs
+++ b/fea-rs/src/token_tree/typed.rs
@@ -1198,6 +1198,13 @@ impl VendorRecord {
     pub(crate) fn value(&self) -> &Token {
         self.find_token(Kind::String).unwrap()
     }
+
+    pub(crate) fn parse_tag(
+        &self,
+    ) -> Result<write_fonts::types::Tag, write_fonts::types::InvalidTag> {
+        let raw = self.value();
+        write_fonts::types::Tag::new_checked(raw.text.trim_matches('"').as_bytes())
+    }
 }
 
 impl Os2NumberList {


### PR DESCRIPTION
We were doing this in two different but equivalent ways in two different places; this standardizes that.