### PR TITLE
Compile FeatureVariations table

### DIFF
--- a/fea-rs/src/bin/compile.rs
+++ b/fea-rs/src/bin/compile.rs
@@ -24,7 +24,8 @@ fn main() -> Result<(), Error> {
     if !fea.exists() {
         return Err(Error::EmptyFeatureFile);
     }
-    let compiled = Compiler::new(fea, &glyph_names)
+    //FIXME: some way to provide variation info from command line?
+    let compiled = Compiler::new(fea, &glyph_names, None)
         .with_opts(Opts::new().make_post_table(args.post))
         .compile()?;
 

--- a/fea-rs/src/compile.rs
+++ b/fea-rs/src/compile.rs
@@ -12,6 +12,10 @@ use self::{
 pub use compiler::Compiler;
 pub use opts::Opts;
 pub use output::Compilation;
+pub use variations::{AxisInfo, VariationInfo};
+
+#[cfg(any(test, feature = "test"))]
+pub(crate) use variations::MockVariationInfo;
 
 mod compile_ctx;
 mod compiler;
@@ -26,10 +30,15 @@ mod tables;
 mod tags;
 mod validate;
 mod valuerecordext;
+mod variations;
 
 /// Run the validation pass, returning any diagnostics.
-pub(crate) fn validate(node: &ParseTree, glyph_map: &GlyphMap) -> Vec<Diagnostic> {
-    let mut ctx = validate::ValidationCtx::new(glyph_map, node.source_map());
+pub(crate) fn validate(
+    node: &ParseTree,
+    glyph_map: &GlyphMap,
+    fvar: Option<&dyn VariationInfo>,
+) -> Vec<Diagnostic> {
+    let mut ctx = validate::ValidationCtx::new(node.source_map(), glyph_map, fvar);
     ctx.validate_root(&node.typed_root());
     ctx.errors
 }

--- a/fea-rs/src/compile/compiler.rs
+++ b/fea-rs/src/compile/compiler.rs
@@ -118,7 +118,7 @@ impl<'a> Compiler<'a> {
         let diagnostics = super::validate(&tree, self.glyph_map, self.var_info);
         print_warnings_return_errors(diagnostics, &tree, self.verbose)
             .map_err(CompilerError::ValidationFail)?;
-        let mut ctx = super::CompilationCtx::new(self.glyph_map, tree.source_map());
+        let mut ctx = super::CompilationCtx::new(self.glyph_map, tree.source_map(), self.var_info);
         ctx.compile(&tree.typed_root());
 
         // we 'take' the errors here because it's easier for us to handle the

--- a/fea-rs/src/compile/variations.rs
+++ b/fea-rs/src/compile/variations.rs
@@ -1,0 +1,72 @@
+//! compiling variable fonts
+
+use write_fonts::types::{Fixed, Tag};
+
+/// A trait for providing variable font information to the compiler.
+///
+/// In order to compile a variable font, we need to know what axes
+/// exist, what ranges are valid, how to map from user to normalized coordinates,
+/// and potentially other things that are not part of the FEA file.
+///
+/// This trait abstracts over that info.
+pub trait VariationInfo {
+    /// If the tag is an axis in this font, return the min/max values from fvar
+    fn axis_info(&self, axis_tag: Tag) -> Option<AxisInfo>;
+}
+
+/// Information about a paritcular axis in a variable font.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct AxisInfo {
+    /// The index in the fvar table of this axis
+    pub index: u16,
+    /// The minimum value for this axis, in user coordinates
+    pub min_value: Fixed,
+    /// The default value for this axis, in user coordinates
+    pub default_value: Fixed,
+    /// The maximum value for this axis, in user coordinates
+    pub max_value: Fixed,
+}
+
+// For testing: a simple list of axes
+#[derive(Clone, Debug, Default)]
+pub(crate) struct MockVariationInfo {
+    axes: Vec<(Tag, AxisInfo)>,
+}
+
+impl MockVariationInfo {
+    /// input is a tuple of (tag, min, default, max)
+    #[cfg(any(test, feature = "test"))]
+    pub(crate) fn new(raw: &[(&str, i16, i16, i16)]) -> Self {
+        Self {
+            axes: raw
+                .iter()
+                .enumerate()
+                .map(|(i, (tag, min, default, max))| {
+                    (
+                        Tag::new_checked(tag.as_bytes()).unwrap(),
+                        AxisInfo {
+                            index: i as u16,
+                            min_value: Fixed::from_i32(*min as _),
+                            default_value: Fixed::from_i32(*default as _),
+                            max_value: Fixed::from_i32(*max as _),
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+}
+
+impl VariationInfo for MockVariationInfo {
+    fn axis_info(&self, axis_tag: Tag) -> Option<AxisInfo> {
+        self.axes.iter().find_map(
+            |(tag, axis)| {
+                if *tag == axis_tag {
+                    Some(*axis)
+                } else {
+                    None
+                }
+            },
+        )
+    }
+}

--- a/fea-rs/src/tests/compile.rs
+++ b/fea-rs/src/tests/compile.rs
@@ -26,11 +26,11 @@ fn fonttools_tests() -> Result<(), Report> {
 #[test]
 fn should_fail() -> Result<(), Report> {
     let mut results = Vec::new();
-    for (glyph_map, fvar, tests) in iter_test_groups(BAD_DIR) {
+    for (glyph_map, var_info, tests) in iter_test_groups(BAD_DIR) {
         results.extend(
             tests
                 .into_iter()
-                .map(|path| run_bad_test(path, &glyph_map, &fvar)),
+                .map(|path| run_bad_test(path, &glyph_map, &var_info)),
         );
     }
     test_utils::finalize_results(results).into_error()
@@ -50,11 +50,11 @@ fn import_resolution() {
 fn should_pass() -> Result<(), Report> {
     let mut results = Vec::new();
 
-    for (glyph_map, fvar, tests) in iter_test_groups(GOOD_DIR) {
+    for (glyph_map, var_info, tests) in iter_test_groups(GOOD_DIR) {
         results.extend(
             tests
                 .into_iter()
-                .map(|path| test_utils::run_test(path, &glyph_map, &fvar)),
+                .map(|path| test_utils::run_test(path, &glyph_map, &var_info)),
         );
     }
     test_utils::finalize_results(results).into_error()
@@ -106,8 +106,8 @@ fn bad_test_body(
     glyph_map: &GlyphMap,
     var_info: &MockVariationInfo,
 ) -> Result<(), TestResult> {
-    let fvar = test_utils::is_variable(&path).then_some(var_info as _);
-    match Compiler::new(path, glyph_map, fvar)
+    let var_info = test_utils::is_variable(path).then_some(var_info as _);
+    match Compiler::new(path, glyph_map, var_info)
         .verbose(std::env::var(crate::util::VERBOSE).is_ok())
         .with_opts(Opts::new().make_post_table(true))
         .compile_binary()

--- a/fea-rs/src/token_tree/typed.rs
+++ b/fea-rs/src/token_tree/typed.rs
@@ -645,10 +645,6 @@ impl Feature {
 }
 
 impl LookupBlock {
-    pub(crate) fn tag(&self) -> &Token {
-        self.find_token(Kind::Label).unwrap()
-    }
-
     #[allow(unused)]
     //TODO: do we want to support this syntax?
     pub(crate) fn use_extension(&self) -> Option<&Token> {

--- a/fea-rs/src/token_tree/typed.rs
+++ b/fea-rs/src/token_tree/typed.rs
@@ -268,6 +268,7 @@ ast_enum!(FloatLike {
 });
 
 ast_node!(ConditionSet, Kind::ConditionSetNode);
+ast_node!(Condition, Kind::ConditionNode);
 ast_node!(FeatureVariation, Kind::VariationNode);
 ast_node!(VariableMetric, Kind::VariableMetricNode);
 ast_enum!(Metric {
@@ -675,8 +676,30 @@ impl LookupBlock {
 }
 
 impl ConditionSet {
+    pub(crate) fn keyword(&self) -> &Token {
+        self.find_token(Kind::ConditionSetKw).unwrap()
+    }
+
     pub(crate) fn label(&self) -> &Token {
         self.find_token(Kind::Label).unwrap()
+    }
+
+    pub(crate) fn conditions(&self) -> impl Iterator<Item = Condition> + '_ {
+        self.iter().filter_map(Condition::cast)
+    }
+}
+
+impl Condition {
+    pub(crate) fn tag(&self) -> Tag {
+        self.iter().find_map(Tag::cast).unwrap()
+    }
+
+    pub(crate) fn min_value(&self) -> Number {
+        self.iter().find_map(Number::cast).unwrap()
+    }
+
+    pub(crate) fn max_value(&self) -> Number {
+        self.iter().filter_map(Number::cast).nth(1).unwrap()
     }
 }
 

--- a/fea-rs/src/util/ttx.rs
+++ b/fea-rs/src/util/ttx.rs
@@ -33,7 +33,6 @@ static IGNORED_TESTS: &[&str] = &[
     "GSUB_8.fea",
     // # tests of variable syntax extension #
     "variable_bug2772.fea",
-    "variable_conditionset.fea",
     "variable_scalar_anchor.fea",
     "variable_scalar_valuerecord.fea",
 ];


### PR DESCRIPTION
This adds support for actually compiling the FeatureVariations table, based on the experimental FEA syntax.

I've learned.. so much.

I have a bunch of lingering questions about this stuff, and it now feels like an open question whether or not this syntax will make any sense in a world with avar2, but I'm not stressing that too much for now.

Computing these tables involves normalizing coordinates; I don't want fea-rs to need to worry about that, so I've added a trait that can be implemented by the compiler. This trait may need to change as we get a better understanding of the problem.

This doesn't add support for compiling variable anchors or value records, which will come next.