### PR TITLE
Use builder method to pass VariationInfo to compiler

### DIFF
--- a/fea-rs/src/bin/compile.rs
+++ b/fea-rs/src/bin/compile.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Error> {
         return Err(Error::EmptyFeatureFile);
     }
     //FIXME: some way to provide variation info from command line?
-    let compiled = Compiler::new(fea, &glyph_names, None)
+    let compiled = Compiler::new(fea, &glyph_names)
         .with_opts(Opts::new().make_post_table(args.post))
         .compile()?;
 

--- a/fea-rs/src/compile/compiler.rs
+++ b/fea-rs/src/compile/compiler.rs
@@ -47,15 +47,11 @@ impl<'a> Compiler<'a> {
     /// identifier that your resolver will resolve.
     ///
     /// [`with_resolver`]: Self::with_resolver
-    pub fn new(
-        root_path: impl Into<OsString>,
-        glyph_map: &'a GlyphMap,
-        var_info: Option<&'a dyn VariationInfo>,
-    ) -> Self {
+    pub fn new(root_path: impl Into<OsString>, glyph_map: &'a GlyphMap) -> Self {
         Compiler {
             root_path: root_path.into(),
             glyph_map,
-            var_info,
+            var_info: None,
             opts: Default::default(),
             verbose: false,
             resolver: Default::default(),
@@ -66,6 +62,12 @@ impl<'a> Compiler<'a> {
     /// Provide a custom `SourceResolver`, for mapping paths to their contents.
     pub fn with_resolver(mut self, resolver: impl SourceResolver + 'static) -> Self {
         self.resolver = Some(Box::new(resolver));
+        self
+    }
+
+    /// Provide [`VariationInfo`], necessary when compiling features for a variable font.
+    pub fn with_variable_info(mut self, var_info: &'a dyn VariationInfo) -> Self {
+        self.var_info = Some(var_info);
         self
     }
 

--- a/fea-rs/src/tests/compile.rs
+++ b/fea-rs/src/tests/compile.rs
@@ -106,12 +106,14 @@ fn bad_test_body(
     glyph_map: &GlyphMap,
     var_info: &MockVariationInfo,
 ) -> Result<(), TestResult> {
-    let var_info = test_utils::is_variable(path).then_some(var_info as _);
-    match Compiler::new(path, glyph_map, var_info)
+    let mut compiler = Compiler::new(path, glyph_map)
         .verbose(std::env::var(crate::util::VERBOSE).is_ok())
-        .with_opts(Opts::new().make_post_table(true))
-        .compile_binary()
-    {
+        .with_opts(Opts::new().make_post_table(true));
+    if test_utils::is_variable(path) {
+        compiler = compiler.with_variable_info(var_info);
+    }
+
+    match compiler.compile_binary() {
         Ok(_) => Err(TestResult::UnexpectedSuccess),
         // this means we have a test case that doesn't exist or something weird
         Err(CompilerError::SourceLoad(err)) => panic!("{err}"),


### PR DESCRIPTION
This is more ergonomic than just cramming it into the `new` method.