### PR TITLE
Parse trailing paripos

### DIFF
--- a/fea-rs/src/token_tree/typed.rs
+++ b/fea-rs/src/token_tree/typed.rs
@@ -989,6 +989,12 @@ impl Gpos6 {
     }
 }
 
+impl Gpos8 {
+    pub(crate) fn trailing_value_record(&self) -> Option<ValueRecord> {
+        self.iter().skip(4).find_map(ValueRecord::cast)
+    }
+}
+
 impl GposIgnore {
     pub(crate) fn rules(&self) -> impl Iterator<Item = IgnoreRule> + '_ {
         self.iter().filter_map(IgnoreRule::cast)

--- a/fea-rs/test-data/compile-tests/mini-latin/good/spec_6iii_3c.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/spec_6iii_3c.fea
@@ -1,0 +1,6 @@
+# http://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#example-3c
+# this is a special case, and should produce a pairpos lookup for f -> 10
+feature kern {
+    pos s f' t period 10;
+    pos a b' c 10;
+} kern;

--- a/fea-rs/test-data/compile-tests/mini-latin/good/spec_6iii_3c.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/spec_6iii_3c.ttx
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="kern"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=2 -->
+      <Lookup index="0">
+        <LookupType value="8"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <ChainContextPos index="0" Format="1">
+          <Coverage>
+            <Glyph value="b"/>
+            <Glyph value="f"/>
+          </Coverage>
+          <!-- ChainPosRuleSetCount=2 -->
+          <ChainPosRuleSet index="0">
+            <!-- ChainPosRuleCount=1 -->
+            <ChainPosRule index="0">
+              <!-- BacktrackGlyphCount=1 -->
+              <Backtrack index="0" value="a"/>
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=1 -->
+              <LookAhead index="0" value="c"/>
+              <!-- PosCount=1 -->
+              <PosLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="1"/>
+              </PosLookupRecord>
+            </ChainPosRule>
+          </ChainPosRuleSet>
+          <ChainPosRuleSet index="1">
+            <!-- ChainPosRuleCount=1 -->
+            <ChainPosRule index="0">
+              <!-- BacktrackGlyphCount=1 -->
+              <Backtrack index="0" value="s"/>
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=2 -->
+              <LookAhead index="0" value="t"/>
+              <LookAhead index="1" value="period"/>
+              <!-- PosCount=1 -->
+              <PosLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="1"/>
+              </PosLookupRecord>
+            </ChainPosRule>
+          </ChainPosRuleSet>
+        </ChainContextPos>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SinglePos index="0" Format="1">
+          <Coverage>
+            <Glyph value="b"/>
+            <Glyph value="f"/>
+          </Coverage>
+          <ValueFormat value="4"/>
+          <Value XAdvance="10"/>
+        </SinglePos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>

--- a/fea-rs/test-data/parse-tests/bad/contextual_inline_pairpos.ERR
+++ b/fea-rs/test-data/parse-tests/bad/contextual_inline_pairpos.ERR
@@ -1,0 +1,11 @@
+error: trailing value record only valid if there is a single marked glyph, no inline lookups, and at least one lookahead glyph.
+in ./test-data/parse-tests/bad/contextual_inline_pairpos.fea at 7:25
+  | 
+7 |     pos a b' lookup hi c 20;
+  |                          ^^
+
+error: trailing value record only valid if there is a single marked glyph, no inline lookups, and at least one lookahead glyph.
+in ./test-data/parse-tests/bad/contextual_inline_pairpos.fea at 9:18
+  | 
+9 |     pos a b' c' d <10 5 0 0>;
+  |                   ^^^^^^^^^^

--- a/fea-rs/test-data/parse-tests/bad/contextual_inline_pairpos.fea
+++ b/fea-rs/test-data/parse-tests/bad/contextual_inline_pairpos.fea
@@ -1,0 +1,11 @@
+lookup hi {
+    pos b 5;
+} hi;
+
+feature kern {
+    # can't have inline pairpos with other lookup
+    pos a b' lookup hi c 20;
+    # can't have inline pairpos with two marked glyphs
+    pos a b' c' d <10 5 0 0>;
+
+} kern;

--- a/fea-rs/test-data/parse-tests/good/spec6iii_3c.PARSE_TREE
+++ b/fea-rs/test-data/parse-tests/good/spec6iii_3c.PARSE_TREE
@@ -1,0 +1,61 @@
+FILE@[0; 162)
+  #@0 "# http://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#example-3c"
+  WS@90 "\n"
+    FeatureNode@[91; 161)
+      FeatureKw@91 "feature"
+      WS@98 " "
+      Tag@99 "kern"
+      WS@103 " "
+      {@104 "{"
+      WS@105 "\n    "
+        GposType8@[110; 124)
+          PosKw@110 "pos"
+          WS@113 " "
+            BacktrackSequence@[114; 115)
+              GlyphName@114 "a"
+          WS@115 " "
+            ContextSequence@[116; 119)
+                ContextGlyphNode@[116; 119)
+                  GlyphName@116 "b"
+                  '@117 "'"
+                  WS@118 " "
+            LookaheadSequence@[119; 120)
+              GlyphName@119 "c"
+          WS@120 " "
+            ValueRecordNode@[121; 123)
+              NUM@121 "10"
+          ;@123 ";"
+      WS@124 "\n    "
+        GposType8@[129; 153)
+          PosKw@129 "pos"
+          WS@132 " "
+            BacktrackSequence@[133; 134)
+              GlyphName@133 "e"
+          WS@134 " "
+            ContextSequence@[135; 138)
+                ContextGlyphNode@[135; 138)
+                  GlyphName@135 "f"
+                  '@136 "'"
+                  WS@137 " "
+            LookaheadSequence@[138; 141)
+              GlyphName@138 "g"
+              WS@139 " "
+              GlyphName@140 "h"
+          WS@141 " "
+            ValueRecordNode@[142; 152)
+              <@142 "<"
+              NUM@143 "12"
+              WS@145 " "
+              NUM@146 "0"
+              WS@147 " "
+              NUM@148 "5"
+              WS@149 " "
+              NUM@150 "0"
+              >@151 ">"
+          ;@152 ";"
+      WS@153 "\n"
+      }@154 "}"
+      WS@155 " "
+      Tag@156 "kern"
+      ;@160 ";"
+  WS@161 "\n"

--- a/fea-rs/test-data/parse-tests/good/spec6iii_3c.fea
+++ b/fea-rs/test-data/parse-tests/good/spec6iii_3c.fea
@@ -1,0 +1,5 @@
+# http://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#example-3c
+feature kern {
+    pos a b' c 10;
+    pos e f' g h <12 0 5 0>;
+} kern;


### PR DESCRIPTION
Per #170, there was a bit of syntax related to contextual GPOS rules that I was not handling correctly.

This was a rabbit hole; the spec seems to have a typo (https://github.com/adobe-type-tools/afdko/issues/1665) and it looks like this syntax isn't included in the fonttools tests, although it does handle it.

I've manually compared our output to fonttools', and we are now generating the same ttx.

relevant to this, it looks like there may be some additional inline GPOS rules that I am not correctly handling, specifically I do not handle [inline cursive](http://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#6hiv-specifying-contextual-positioning-with-in-line-cursive-positioning-rules) or [inline mark positioning](http://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#6hv-specifying-contextual-positioning-with-in-line-mark-attachment-positioning-rules) rules.