### PR TITLE
Add full parse test for glyph/range disambiguation

### DIFF
--- a/fea-rs/src/common/glyph_map.rs
+++ b/fea-rs/src/common/glyph_map.rs
@@ -46,6 +46,13 @@ impl GlyphMap {
             .collect()
     }
 
+    /// Iterate the idents in this map, in GID order.
+    ///
+    /// This is really only intended to be used to create new glyphmaps for testing.
+    pub fn iter(&self) -> impl Iterator<Item = GlyphIdent> + '_ {
+        self.reverse_map().into_values()
+    }
+
     /// Return `true` if the map contains the provided `GlyphIdent`.
     pub fn contains<Q: ?Sized + sealed::AsGlyphIdent>(&self, key: &Q) -> bool {
         if let Some(name) = key.named() {

--- a/fea-rs/src/tests/compile.rs
+++ b/fea-rs/src/tests/compile.rs
@@ -38,7 +38,7 @@ fn should_fail() -> Result<(), Report> {
 
 #[test]
 fn import_resolution() {
-    let glyph_map = test_utils::make_glyph_map();
+    let glyph_map = test_utils::fonttools_test_glyph_order();
     let path = PathBuf::from(IMPORT_RESOLUTION_TEST);
     match test_utils::run_test(path, &glyph_map, &Default::default()) {
         Ok(_) => (),

--- a/fea-rs/src/util/ttx.rs
+++ b/fea-rs/src/util/ttx.rs
@@ -15,7 +15,7 @@ use crate::{
         error::{CompilerError, DiagnosticSet},
         Compiler, MockVariationInfo, Opts,
     },
-    Diagnostic, GlyphIdent, GlyphMap, GlyphName, ParseTree,
+    Diagnostic, GlyphIdent, GlyphMap, ParseTree,
 };
 
 use ansi_term::Color;
@@ -151,7 +151,7 @@ impl<'a> Filter<'a> {
 /// `filter` is an optional comma-separated list of strings. If present, only
 /// tests which contain one of the strings in the list will be run.
 pub fn run_all_tests(fonttools_data_dir: impl AsRef<Path>, filter: Option<&String>) -> Report {
-    let glyph_map = make_glyph_map();
+    let glyph_map = fonttools_test_glyph_order();
     let filter = Filter::new(filter);
     let var_info = make_var_info();
 
@@ -520,42 +520,11 @@ pub fn plain_text_diff(left: &str, right: &str) -> String {
 /// Generate the sample glyph map.
 ///
 /// This is the glyph map used in the feaLib test suite.
-pub fn make_glyph_map() -> GlyphMap {
-    #[rustfmt::skip]
-static TEST_FONT_GLYPHS: &[&str] = &[
-    ".notdef", "space", "slash", "fraction", "semicolon", "period", "comma",
-    "ampersand", "quotedblleft", "quotedblright", "quoteleft", "quoteright",
-    "zero", "one", "two", "three", "four", "five", "six", "seven", "eight",
-    "nine", "zero.oldstyle", "one.oldstyle", "two.oldstyle",
-    "three.oldstyle", "four.oldstyle", "five.oldstyle", "six.oldstyle",
-    "seven.oldstyle", "eight.oldstyle", "nine.oldstyle", "onequarter",
-    "onehalf", "threequarters", "onesuperior", "twosuperior",
-    "threesuperior", "ordfeminine", "ordmasculine", "A", "B", "C", "D", "E",
-    "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S",
-    "T", "U", "V", "W", "X", "Y", "Z", "a", "b", "c", "d", "e", "f", "g",
-    "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u",
-    "v", "w", "x", "y", "z", "A.sc", "B.sc", "C.sc", "D.sc", "E.sc", "F.sc",
-    "G.sc", "H.sc", "I.sc", "J.sc", "K.sc", "L.sc", "M.sc", "N.sc", "O.sc",
-    "P.sc", "Q.sc", "R.sc", "S.sc", "T.sc", "U.sc", "V.sc", "W.sc", "X.sc",
-    "Y.sc", "Z.sc", "A.alt1", "A.alt2", "A.alt3", "B.alt1", "B.alt2",
-    "B.alt3", "C.alt1", "C.alt2", "C.alt3", "a.alt1", "a.alt2", "a.alt3",
-    "a.end", "b.alt", "c.mid", "d.alt", "d.mid", "e.begin", "e.mid",
-    "e.end", "m.begin", "n.end", "s.end", "z.end", "Eng", "Eng.alt1",
-    "Eng.alt2", "Eng.alt3", "A.swash", "B.swash", "C.swash", "D.swash",
-    "E.swash", "F.swash", "G.swash", "H.swash", "I.swash", "J.swash",
-    "K.swash", "L.swash", "M.swash", "N.swash", "O.swash", "P.swash",
-    "Q.swash", "R.swash", "S.swash", "T.swash", "U.swash", "V.swash",
-    "W.swash", "X.swash", "Y.swash", "Z.swash", "f_l", "c_h", "c_k", "c_s",
-    "c_t", "f_f", "f_f_i", "f_f_l", "f_i", "o_f_f_i", "s_t", "f_i.begin",
-    "a_n_d", "T_h", "T_h.swash", "germandbls", "ydieresis", "yacute",
-    "breve", "grave", "acute", "dieresis", "macron", "circumflex",
-    "cedilla", "umlaut", "ogonek", "caron", "damma", "hamza", "sukun",
-    "kasratan", "lam_meem_jeem", "noon.final", "noon.initial", "by",
-    "feature", "lookup", "sub", "table", "uni0327", "uni0328", "e.fina",
-];
-    TEST_FONT_GLYPHS
+pub fn fonttools_test_glyph_order() -> GlyphMap {
+    let order_str = std::fs::read_to_string("./test-data/simple_glyph_order.txt").unwrap();
+    crate::compile::parse_glyph_order(&order_str)
+        .unwrap()
         .iter()
-        .map(|name| GlyphIdent::Name(GlyphName::new(*name)))
         .chain((800_u16..=1001).map(GlyphIdent::Cid))
         .collect()
 }

--- a/fea-rs/test-data/parse-tests/good/glyph_or_range.PARSE_TREE
+++ b/fea-rs/test-data/parse-tests/good/glyph_or_range.PARSE_TREE
@@ -1,0 +1,38 @@
+FILE@[0; 99)
+    FeatureNode@[0; 98)
+      FeatureKw@0 "feature"
+      WS@7 " "
+      Tag@8 "derp"
+      WS@12 " "
+      {@13 "{"
+      WS@14 "\n    "
+        GposType1@[19; 30)
+          PosKw@19 "pos"
+          WS@22 " "
+            GlyphRange@[23; 26)
+              GlyphName@23 "a"
+              -@24 "-"
+              GlyphName@25 "z"
+          WS@26 " "
+            ValueRecordNode@[27; 29)
+              NUM@27 "10"
+          ;@29 ";"
+      WS@30 " "
+      #@31 "# this is range"
+      WS@46 "\n    "
+        GposType1@[51; 67)
+          PosKw@51 "pos"
+          WS@54 " "
+          GlyphName@55 "two-four"
+          WS@63 " "
+            ValueRecordNode@[64; 66)
+              NUM@64 "15"
+          ;@66 ";"
+      WS@67 " "
+      #@68 "# this is a glyph name"
+      WS@90 "\n"
+      }@91 "}"
+      WS@92 " "
+      Tag@93 "derp"
+      ;@97 ";"
+  WS@98 "\n"

--- a/fea-rs/test-data/parse-tests/good/glyph_or_range.fea
+++ b/fea-rs/test-data/parse-tests/good/glyph_or_range.fea
@@ -1,0 +1,4 @@
+feature derp {
+    pos a-z 10; # this is range
+    pos two-four 15; # this is a glyph name
+} derp;


### PR DESCRIPTION
Another thing motivated by investigating #170; it seems like ambiguous tokens are persisting after where I would expect, so I wanted to improve the testing of this.

- A glyph range is specified with the syntax 'a - z', where the spaces around the hyphen are optional.
- A hyphen is a valid character in a glyph name
- Ergo, 'a-z' could either be the range of glyphs from 'a' to 'z', or the name of a single glyph, 'a-z'.
- In order to parse this correctly, you need a list of glyph names.

I have other tests for this, but I didn't have an integration test, and in the course of adding it I discovered that,

- the sample glyph list we use (taken from what fonttools uses) was included in two places. So I fixed that.
- the parse tests were not currently passing in a glyph map at all; now they are.
- there was no easy way to add a glyph to an existing glyph map, and now there sort of is. (this is only useful for testing)

And after all that, we have a test, and it's passing.