### PR TITLE
Bump version to 0.8.1

### DIFF
--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fea-rs"
-version = "0.8.0"
+version = "0.8.1"
 license = "MIT/Apache-2.0"
 authors = ["Colin Rofls <colin@cmyr.net>"]
 description = "Tools for working with Adobe OpenType Feature files."


### PR DESCRIPTION
This will let us update fontc, so that the everyone can see the current errors produced on problem fonts.