### PR TITLE
Tweak validation behaviour of redefined lookupflags

### DIFF
--- a/fea-rs/test-data/compile-tests/mini-latin/bad/lookup_multiple_flags.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/lookup_multiple_flags.fea
@@ -5,3 +5,10 @@ lookup foo {
     lookupflag 2;
     sub x by y;
 } foo;
+
+# this is fine, since no rules in the lookup use the second lookupflag
+lookup bar {
+    lookupflag 1;
+    sub g by h;
+    lookupflag 0;
+} bar;


### PR DESCRIPTION
A single lookup can only contain rules with a single lookupflag; our previous validation pass errored anytime a lookupflag statement occured after a rule, but this misses the case where a lookupflag statement occurs after the last rule, and thus is not applied to any rule in the containing lookup.

This was one of the issues in #170.