### PR TITLE
Sketch out API for getting deltas from the compiler

### DIFF
--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -1053,7 +1053,7 @@ impl<'a> CompilationCtx<'a> {
 
         let Some([x_place, y_place, x_adv, y_adv]) = record.placement() else {
             log::error!("failed to resolve value record. This indicates a bug.");
-                return Default::default();
+            return Default::default();
         };
 
         let (x_place, _x_place_dev) = self.resolve_metric(&x_place);
@@ -1116,8 +1116,13 @@ impl<'a> CompilationCtx<'a> {
                 (user_loc, value)
             })
             .collect::<HashMap<_, _>>();
-        let (default, deltas) = var_info.resolve_variable_metric(&locations);
-        (default, self.tables.var_store().add_deltas(deltas))
+        match var_info.resolve_variable_metric(&locations) {
+            Ok((default, deltas)) => (default, self.tables.var_store().add_deltas(deltas)),
+            Err(e) => {
+                self.error(metric.range(), format!("failed to compute deltas: '{e}'"));
+                (0, DeltaKey::NO_DELTAS)
+            }
+        }
     }
 
     fn define_glyph_class(&mut self, class_decl: typed::GlyphClassDef) {

--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -41,7 +41,7 @@ use super::{
         AllLookups, FilterSetId, LookupFlagInfo, LookupId, PreviouslyAssignedClass, SomeLookup,
     },
     output::Compilation,
-    tables::{ClassId, ScriptRecord, Tables},
+    tables::{ClassId, DeltaKey, ScriptRecord, Tables},
     tags,
     valuerecordext::ValueRecordExt,
     VariationInfo,
@@ -1050,37 +1050,74 @@ impl<'a> CompilationCtx<'a> {
                 ..Default::default()
             };
         }
-        if let Some([x_place, y_place, x_adv, y_adv]) = record.placement() {
-            let (Some(x_place), Some(y_place), Some(x_adv), Some(y_adv)) = (x_place.parse_simple(), y_place.parse_simple(), x_adv.parse_simple(), y_adv.parse_simple()) else {
-                self.error(record.range(), "variable metrics not yet supported");
-                return Default::default();
-            };
-            let mut result = ValueRecord {
-                x_advance: Some(x_adv),
-                y_advance: Some(y_adv),
-                x_placement: Some(x_place),
-                y_placement: Some(y_place),
-                ..Default::default()
-            };
-            if let Some([x_place_dev, y_place_dev, x_adv_dev, y_adv_dev]) = record.device() {
-                if let Some(x_place_dev) = x_place_dev.compile() {
-                    result.x_placement_device.set(x_place_dev);
-                }
-                if let Some(y_place_dev) = y_place_dev.compile() {
-                    result.y_placement_device.set(y_place_dev);
-                }
-                if let Some(x_adv_dev) = x_adv_dev.compile() {
-                    result.x_advance_device.set(x_adv_dev);
-                }
-                if let Some(y_adv_dev) = y_adv_dev.compile() {
-                    result.y_advance_device.set(y_adv_dev);
-                }
-            }
-            return result;
-        }
 
-        log::warn!("failed to resolve value record. This indicates a bug.");
-        ValueRecord::default()
+        let Some([x_place, y_place, x_adv, y_adv]) = record.placement() else {
+            log::error!("failed to resolve value record. This indicates a bug.");
+                return Default::default();
+        };
+
+        let (x_place, _x_place_dev) = self.resolve_metric(&x_place);
+        let (y_place, _y_place_dev) = self.resolve_metric(&y_place);
+        let (x_adv, _x_adv_dev) = self.resolve_metric(&x_adv);
+        let (y_adv, _y_adv_dev) = self.resolve_metric(&y_adv);
+
+        let mut result = ValueRecord {
+            x_advance: Some(x_adv),
+            y_advance: Some(y_adv),
+            x_placement: Some(x_place),
+            y_placement: Some(y_place),
+            ..Default::default()
+        };
+
+        if let Some([x_place_dev, y_place_dev, x_adv_dev, y_adv_dev]) = record.device() {
+            if let Some(x_place_dev) = x_place_dev.compile() {
+                result.x_placement_device.set(x_place_dev);
+            }
+            if let Some(y_place_dev) = y_place_dev.compile() {
+                result.y_placement_device.set(y_place_dev);
+            }
+            if let Some(x_adv_dev) = x_adv_dev.compile() {
+                result.x_advance_device.set(x_adv_dev);
+            }
+            if let Some(y_adv_dev) = y_adv_dev.compile() {
+                result.y_advance_device.set(y_adv_dev);
+            }
+        }
+        result
+    }
+
+    fn resolve_metric(&mut self, metric: &typed::Metric) -> (i16, DeltaKey) {
+        match metric {
+            typed::Metric::Scalar(value) => (value.parse_signed(), DeltaKey::NO_DELTAS),
+            typed::Metric::Variable(variable) => self.resolve_variable_metric(variable),
+        }
+    }
+
+    fn resolve_variable_metric(&mut self, metric: &typed::VariableMetric) -> (i16, DeltaKey) {
+        let Some(var_info) = self.variation_info else {
+            self.error(metric.range(), "variable metric only valid when compiling variable font");
+            return (0, DeltaKey::NO_DELTAS)
+        };
+
+        let locations = metric
+            .location_values()
+            .map(|loc_value| {
+                let user_loc = loc_value
+                    .location()
+                    .items()
+                    .map(|axis_value| {
+                        (
+                            axis_value.axis_tag().to_raw(),
+                            Fixed::from_i32(axis_value.value().parse_signed() as _),
+                        )
+                    })
+                    .collect();
+                let value = loc_value.value().parse_signed();
+                (user_loc, value)
+            })
+            .collect::<HashMap<_, _>>();
+        let (default, deltas) = var_info.resolve_variable_metric(&locations);
+        (default, self.tables.var_store().add_deltas(deltas))
     }
 
     fn define_glyph_class(&mut self, class_decl: typed::GlyphClassDef) {

--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -1764,10 +1764,22 @@ impl<'a> CompilationCtx<'a> {
             }
         }
 
-        let Some((x, y)) = item.coords().and_then(|(x, y)| x.parse_simple().zip(y.parse_simple())) else {
-            self.error(item.range(), "variable anchor compilation not yet implemented");
+        let Some((x, y)) = item.coords() else {
+            self.error(item.range(), "unexpected parse failure, please file a bug");
             return None;
         };
+
+        let (x, x_var) = self.resolve_metric(&x);
+        let (y, y_var) = self.resolve_metric(&y);
+
+        if x_var.is_some() || y_var.is_some() {
+            return Some(AnchorTable::format_3(
+                x,
+                y,
+                x_var.map(Into::into),
+                y_var.map(Into::into),
+            ));
+        }
 
         if let Some(point) = item.contourpoint() {
             match point.parse_unsigned() {

--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -14,7 +14,7 @@ use write_fonts::{
         self,
         gdef::CaretValue,
         gpos::{AnchorTable, ValueRecord},
-        layout::{ConditionFormat1, ConditionSet, FeatureVariations, LookupFlag},
+        layout::{ConditionFormat1, ConditionSet, FeatureVariations, LookupFlag, VariationIndex},
     },
     types::{Fixed, NameId, Tag},
 };
@@ -41,7 +41,7 @@ use super::{
         AllLookups, FilterSetId, LookupFlagInfo, LookupId, PreviouslyAssignedClass, SomeLookup,
     },
     output::Compilation,
-    tables::{ClassId, DeltaKey, ScriptRecord, Tables},
+    tables::{ClassId, ScriptRecord, Tables},
     tags,
     valuerecordext::ValueRecordExt,
     VariationInfo,
@@ -1086,17 +1086,20 @@ impl<'a> CompilationCtx<'a> {
         result
     }
 
-    fn resolve_metric(&mut self, metric: &typed::Metric) -> (i16, DeltaKey) {
+    fn resolve_metric(&mut self, metric: &typed::Metric) -> (i16, Option<VariationIndex>) {
         match metric {
-            typed::Metric::Scalar(value) => (value.parse_signed(), DeltaKey::NO_DELTAS),
+            typed::Metric::Scalar(value) => (value.parse_signed(), None),
             typed::Metric::Variable(variable) => self.resolve_variable_metric(variable),
         }
     }
 
-    fn resolve_variable_metric(&mut self, metric: &typed::VariableMetric) -> (i16, DeltaKey) {
+    fn resolve_variable_metric(
+        &mut self,
+        metric: &typed::VariableMetric,
+    ) -> (i16, Option<VariationIndex>) {
         let Some(var_info) = self.variation_info else {
             self.error(metric.range(), "variable metric only valid when compiling variable font");
-            return (0, DeltaKey::NO_DELTAS)
+            return (0, None)
         };
 
         let locations = metric
@@ -1117,10 +1120,14 @@ impl<'a> CompilationCtx<'a> {
             })
             .collect::<HashMap<_, _>>();
         match var_info.resolve_variable_metric(&locations) {
-            Ok((default, deltas)) => (default, self.tables.var_store().add_deltas(deltas)),
+            Ok((default, deltas)) => {
+                let temp_idx = self.tables.var_store().add_deltas(deltas);
+                let var_idx = VariationIndex::new(temp_idx.outer, temp_idx.inner);
+                (default, Some(var_idx))
+            }
             Err(e) => {
                 self.error(metric.range(), format!("failed to compute deltas: '{e}'"));
-                (0, DeltaKey::NO_DELTAS)
+                (0, None)
             }
         }
     }

--- a/fea-rs/src/compile/tables.rs
+++ b/fea-rs/src/compile/tables.rs
@@ -24,7 +24,7 @@ mod os2;
 mod stat;
 
 pub(crate) use base::{BaseBuilder, ScriptRecord};
-pub(crate) use gdef::{ClassId, DeltaKey, GdefBuilder, VariationStoreBuilder};
+pub(crate) use gdef::{ClassId, GdefBuilder, VariationStoreBuilder};
 pub(crate) use name::{NameBuilder, NameSpec};
 pub(crate) use os2::{CodePageRange, Os2Builder};
 pub(crate) use stat::{AxisLocation, AxisRecord, AxisValue, StatBuilder, StatFallbackName};

--- a/fea-rs/src/compile/tables.rs
+++ b/fea-rs/src/compile/tables.rs
@@ -24,7 +24,7 @@ mod os2;
 mod stat;
 
 pub(crate) use base::{BaseBuilder, ScriptRecord};
-pub(crate) use gdef::{ClassId, GdefBuilder};
+pub(crate) use gdef::{ClassId, DeltaKey, GdefBuilder, VariationStoreBuilder};
 pub(crate) use name::{NameBuilder, NameSpec};
 pub(crate) use os2::{CodePageRange, Os2Builder};
 pub(crate) use stat::{AxisLocation, AxisRecord, AxisValue, StatBuilder, StatFallbackName};
@@ -42,6 +42,7 @@ pub(crate) struct Tables {
     pub os2: Option<Os2Builder>,
     pub stat: Option<StatBuilder>,
 }
+
 #[derive(Clone, Debug, Default)]
 pub(crate) struct HeadBuilder {
     pub font_revision: Fixed,
@@ -51,6 +52,16 @@ pub(crate) struct HeadBuilder {
 pub(crate) struct VmtxBuilder {
     pub origins_y: Vec<(GlyphId, i16)>,
     pub advances_y: Vec<(GlyphId, i16)>,
+}
+
+impl Tables {
+    // convenience method to access the varstore, creating it if it doesn't exist
+    pub(crate) fn var_store(&mut self) -> &mut VariationStoreBuilder {
+        self.gdef
+            .get_or_insert_with(Default::default)
+            .var_store
+            .get_or_insert_with(Default::default)
+    }
 }
 
 // this is the value used in python fonttools when writing this table

--- a/fea-rs/src/compile/tables/gdef.rs
+++ b/fea-rs/src/compile/tables/gdef.rs
@@ -8,6 +8,7 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
+use write_fonts::tables::variations::VariationRegion;
 use write_fonts::types::GlyphId;
 
 use write_fonts::tables::{
@@ -21,12 +22,13 @@ use write_fonts::tables::{
 use crate::common::GlyphClass;
 
 #[derive(Clone, Debug, Default)]
-pub struct GdefBuilder {
+pub(crate) struct GdefBuilder {
     pub glyph_classes: HashMap<GlyphId, ClassId>,
     pub attach: BTreeMap<GlyphId, BTreeSet<u16>>,
     pub ligature_pos: BTreeMap<GlyphId, Vec<CaretValue>>,
     pub mark_attach_class: BTreeMap<GlyphId, u16>,
     pub mark_glyph_sets: Vec<GlyphClass>,
+    pub var_store: Option<VariationStoreBuilder>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -36,6 +38,27 @@ pub enum ClassId {
     Ligature = 2,
     Mark = 3,
     Component = 4,
+}
+
+/// placeholder for type that will build the gdef item variation store if needed?
+///
+/// this probably ends up living in write-fonts
+#[derive(Clone, Debug, Default)]
+pub(crate) struct VariationStoreBuilder {
+    // FIXME write some code?
+}
+
+/// A key that identifies a particular deltaset in an ItemVariationStore.
+///
+/// This corresponds to the outer/inner mapping used to identify deltas.
+/// While constructing a variation store we assign a temporary key to inserted
+/// deltas; these are reordered when the store is built, at which point any
+/// items that reference the store will need to be remapped from their temporary
+/// key to their final one.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct DeltaKey {
+    pub outer: u16,
+    pub inner: u16,
 }
 
 impl From<ClassId> for GlyphClassDef {
@@ -135,6 +158,20 @@ impl GdefBuilder {
             && self.ligature_pos.is_empty()
             && self.mark_attach_class.is_empty()
             && self.mark_glyph_sets.is_empty()
+    }
+}
+
+impl DeltaKey {
+    pub const NO_DELTAS: DeltaKey = DeltaKey {
+        outer: 0xFFFF,
+        inner: 0xFFFF,
+    };
+}
+
+impl VariationStoreBuilder {
+    pub(crate) fn add_deltas(&mut self, _deltas: Vec<(VariationRegion, i16)>) -> DeltaKey {
+        //FIXME: write some code
+        DeltaKey { outer: 0, inner: 0 }
     }
 }
 

--- a/fea-rs/src/compile/tables/gdef.rs
+++ b/fea-rs/src/compile/tables/gdef.rs
@@ -162,6 +162,7 @@ impl GdefBuilder {
 }
 
 impl DeltaKey {
+    #[allow(dead_code)]
     pub const NO_DELTAS: DeltaKey = DeltaKey {
         outer: 0xFFFF,
         inner: 0xFFFF,

--- a/fea-rs/src/compile/variations.rs
+++ b/fea-rs/src/compile/variations.rs
@@ -23,12 +23,17 @@ pub trait VariationInfo {
     /// NOTE: This is only used for computing the normalized values for ConditionSets.
     fn normalize_coordinate(&self, axis_tag: Tag, value: Fixed) -> F2Dot14;
 
-    /// return the default value, and then the regions and their deltas.
+    /// Compute default & deltas for a set of locations and values in variation space.
+    ///
+    /// On success, returns the default value for this set of locations, as well
+    /// as a set of deltas suitable for inclusing in an `ItemVariationStore`.
     fn resolve_variable_metric(
         &self,
         locations: &HashMap<UserLocation, i16>,
-    ) -> (i16, Vec<(VariationRegion, i16)>);
+    ) -> Result<(i16, Vec<(VariationRegion, i16)>), AnyError>;
 }
+
+type AnyError = Box<dyn std::error::Error>;
 
 // btreemap only because hashmap is not hashable
 type UserLocation = BTreeMap<Tag, Fixed>;
@@ -107,7 +112,7 @@ impl VariationInfo for MockVariationInfo {
     fn resolve_variable_metric(
         &self,
         _locations: &HashMap<UserLocation, i16>,
-    ) -> (i16, Vec<(VariationRegion, i16)>) {
-        Default::default()
+    ) -> Result<(i16, Vec<(VariationRegion, i16)>), Box<(dyn std::error::Error + 'static)>> {
+        Ok(Default::default())
     }
 }

--- a/fea-rs/src/compile/variations.rs
+++ b/fea-rs/src/compile/variations.rs
@@ -1,6 +1,11 @@
 //! compiling variable fonts
 
-use write_fonts::types::{F2Dot14, Fixed, Tag};
+use std::collections::{BTreeMap, HashMap};
+
+use write_fonts::{
+    tables::variations::VariationRegion,
+    types::{F2Dot14, Fixed, Tag},
+};
 
 /// A trait for providing variable font information to the compiler.
 ///
@@ -14,8 +19,19 @@ pub trait VariationInfo {
     fn axis_info(&self, axis_tag: Tag) -> Option<AxisInfo>;
 
     /// Return the normalized value for a user coordinate for the given axis.
+    ///
+    /// NOTE: This is only used for computing the normalized values for ConditionSets.
     fn normalize_coordinate(&self, axis_tag: Tag, value: Fixed) -> F2Dot14;
+
+    /// return the default value, and then the regions and their deltas.
+    fn resolve_variable_metric(
+        &self,
+        locations: &HashMap<UserLocation, i16>,
+    ) -> (i16, Vec<(VariationRegion, i16)>);
 }
+
+// btreemap only because hashmap is not hashable
+type UserLocation = BTreeMap<Tag, Fixed>;
 
 /// Information about a paritcular axis in a variable font.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -86,5 +102,12 @@ impl VariationInfo for MockVariationInfo {
             Equal => Fixed::ZERO,
         };
         value.clamp(-Fixed::ONE, Fixed::ONE).to_f2dot14()
+    }
+
+    fn resolve_variable_metric(
+        &self,
+        _locations: &HashMap<UserLocation, i16>,
+    ) -> (i16, Vec<(VariationRegion, i16)>) {
+        Default::default()
     }
 }

--- a/fea-rs/src/token_tree/typed.rs
+++ b/fea-rs/src/token_tree/typed.rs
@@ -1269,6 +1269,10 @@ impl LocationValue {
     pub(crate) fn location(&self) -> LocationSpec {
         self.iter().find_map(LocationSpec::cast).unwrap()
     }
+
+    pub(crate) fn value(&self) -> Number {
+        self.iter().find_map(Number::cast).unwrap()
+    }
 }
 
 impl LocationSpec {


### PR DESCRIPTION
This is a MVP-type sketch of something that passes variable metrics to the compiler for resolution.

The compiler would be required to implement the `VariationInfo` trait, defined in compile/variations.rs; in particular the `resolve_variable_metric` method.


@rsheeter this is the barest-bones interface I can imagine. As much as possible I am avoiding custom types, in favour of types in `write-fonts`. It isn't currently hooked up to anything; in addition to needing to wire this up to whatever is computing the deltas, I'll also need to implement something to build the final ItemVariationStore.