### PR TITLE
Fixup loading of test-data for non-tests

### DIFF
--- a/fea-rs/src/util/ttx.rs
+++ b/fea-rs/src/util/ttx.rs
@@ -520,8 +520,22 @@ pub fn plain_text_diff(left: &str, right: &str) -> String {
 /// Generate the sample glyph map.
 ///
 /// This is the glyph map used in the feaLib test suite.
-pub fn fonttools_test_glyph_order() -> GlyphMap {
-    let order_str = std::fs::read_to_string("./test-data/simple_glyph_order.txt").unwrap();
+pub(crate) fn fonttools_test_glyph_order() -> GlyphMap {
+    let cwd = std::env::current_dir().expect("could not retrieve current directory");
+    // hack: during testing cwd is the crate root, but when running a binary
+    // it may be the project root
+    let path = if cwd.parent().expect("always present").ends_with("fea-rs") {
+        "./test-data/simple_glyph_order.txt"
+    } else {
+        "./fea-rs/test-data/simple_glyph_order.txt"
+    };
+    if !Path::new(path).exists() {
+        panic!(
+            "could not locate glyph order file (cwd '{}', path '{path}' )",
+            cwd.display()
+        );
+    }
+    let order_str = std::fs::read_to_string(path).unwrap();
     crate::compile::parse_glyph_order(&order_str)
         .unwrap()
         .iter()


### PR DESCRIPTION
I call a function that loads a file from a relative path. It is called two different ways; either when running `cargo test`, or when running the ttx_test binary.

`cargo test` runs tests for a given crate from that crate's root directory, but cargo run --bin=x can be run from the crate root; so I need to ensure that I use the correct relative for both of these cases.

I really don't know what the principled approach to this is, outside of baking the file into the binary at compile time? But this at least fixes my concrete problem.