### PR TITLE
Support mixed GSUB Type 1 and Type 2 rules

### DIFF
--- a/fea-rs/src/compile/lookups/gsub.rs
+++ b/fea-rs/src/compile/lookups/gsub.rs
@@ -44,6 +44,16 @@ impl SingleSubBuilder {
     pub(crate) fn iter_pairs(&self) -> impl Iterator<Item = (GlyphId, GlyphId)> + '_ {
         self.items.iter().map(|(target, (alt, _))| (*target, *alt))
     }
+
+    pub(crate) fn promote_to_multi_sub(self) -> MultipleSubBuilder {
+        MultipleSubBuilder {
+            items: self
+                .items
+                .into_iter()
+                .map(|(key, (gid, _))| (key, vec![gid]))
+                .collect(),
+        }
+    }
 }
 
 impl Builder for SingleSubBuilder {

--- a/fea-rs/src/compile/validate.rs
+++ b/fea-rs/src/compile/validate.rs
@@ -761,6 +761,9 @@ impl<'a> ValidationCtx<'a> {
         for item in node.statements() {
             if item.kind().is_rule() {
                 match kind {
+                    // we allow mixed rules in this specific case
+                    Some(Kind::GsubType1 | Kind::GsubType2)
+                        if matches!(item.kind(), Kind::GsubType1 | Kind::GsubType2) => {}
                     Some(kind) if kind != item.kind() => self.error(
                         item.range(),
                         format!(

--- a/fea-rs/test-data/compile-tests/mini-latin/good/gpos_mixed_single_multi_rules.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/gpos_mixed_single_multi_rules.fea
@@ -1,0 +1,15 @@
+# when a lookup block contains mixed single & multi-sub rules, we combine
+# them into a single multi-sub lookup.
+lookup mixed {
+    # single sub rules:
+    sub [c d] by E;
+    sub b by B;
+    # ligature decomposition/multi sub rules:
+    sub F by f f;
+} mixed;
+
+# we also want to allow single rules to follow multi, and be promoted
+lookup also_mixed {
+    sub F by f f;
+    sub b by B;
+} also_mixed;

--- a/fea-rs/test-data/compile-tests/mini-latin/good/gpos_mixed_single_multi_rules.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/gpos_mixed_single_multi_rules.ttx
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=2 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <MultipleSubst index="0">
+          <Substitution in="F" out="f,f"/>
+          <Substitution in="b" out="B"/>
+          <Substitution in="c" out="E"/>
+          <Substitution in="d" out="E"/>
+        </MultipleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="2"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <MultipleSubst index="0">
+          <Substitution in="F" out="f,f"/>
+          <Substitution in="b" out="B"/>
+        </MultipleSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>

--- a/fea-rs/test-data/compile-tests/mini-latin/good/gsub1.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/gsub1.fea
@@ -18,5 +18,6 @@ feature noos {
 feature nono {
     # technically creates a type-2 lookup: multisub with an empty target sequence
     sub @numbers by NULL;
+    # that means this will also be type-2, since we combine mixed single&multi rules.
     sub @numbers_old_style by question;
 } nono;

--- a/fea-rs/test-data/compile-tests/mini-latin/good/gsub1.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/gsub1.ttx
@@ -24,9 +24,8 @@
       <FeatureRecord index="0">
         <FeatureTag value="nono"/>
         <Feature>
-          <!-- LookupCount=2 -->
+          <!-- LookupCount=1 -->
           <LookupListIndex index="0" value="2"/>
-          <LookupListIndex index="1" value="3"/>
         </Feature>
       </FeatureRecord>
       <FeatureRecord index="1">
@@ -45,7 +44,7 @@
       </FeatureRecord>
     </FeatureList>
     <LookupList>
-      <!-- LookupCount=4 -->
+      <!-- LookupCount=3 -->
       <Lookup index="0">
         <LookupType value="1"/>
         <LookupFlag value="0"/>
@@ -74,21 +73,14 @@
         <!-- SubTableCount=1 -->
         <MultipleSubst index="0">
           <Substitution in="four" out=""/>
-          <Substitution in="one" out=""/>
-          <Substitution in="three" out=""/>
-          <Substitution in="two" out=""/>
-        </MultipleSubst>
-      </Lookup>
-      <Lookup index="3">
-        <LookupType value="1"/>
-        <LookupFlag value="0"/>
-        <!-- SubTableCount=1 -->
-        <SingleSubst index="0">
           <Substitution in="four.osf" out="question"/>
+          <Substitution in="one" out=""/>
           <Substitution in="one.osf" out="question"/>
+          <Substitution in="three" out=""/>
           <Substitution in="three.osf" out="question"/>
+          <Substitution in="two" out=""/>
           <Substitution in="two.osf" out="question"/>
-        </SingleSubst>
+        </MultipleSubst>
       </Lookup>
     </LookupList>
   </GSUB>


### PR DESCRIPTION
In the case where a lookup contains mixed Single and Multiple Substitution rules, we will combine them all into a single Multiple substitution lookup.

This matches the behaviour of fonttools, and has nominal blessing from adobe (https://github.com/adobe-type-tools/afdko/issues/224#issuecomment-537215163) although that has not made it into the spec.


- fixes #180
- last work for #170