### PR TITLE
Remap VarStore references after compilation

### DIFF
--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -181,11 +181,11 @@ impl<'a> CompilationCtx<'a> {
             Some((gdef, key_map)) => (Some(gdef), key_map),
             None => (None, None),
         };
-        // all VariationIndex tables (in value records and anchors) currently
-        // have temporary indices; now that we've built the ItemVariationStore
-        // we need to go and update them all.
-        if let Some(_key_map) = key_map {
-            log::error!("TODO: go and remap VariationIndex values");
+        // all VariationIndex tables (in value records and anchors) currently have
+        // temporary indices; now that we've built the ItemVariationStore we need
+        // to go and update them all.
+        if let Some(key_map) = key_map {
+            self.lookups.update_variation_index_tables(&key_map);
         }
 
         let (mut gsub, mut gpos) = self.lookups.build(&self.features);

--- a/fea-rs/src/compile/tables/var_store.rs
+++ b/fea-rs/src/compile/tables/var_store.rs
@@ -3,8 +3,9 @@
 use std::collections::HashMap;
 
 use indexmap::IndexMap;
-use write_fonts::tables::variations::{
-    ItemVariationData, ItemVariationStore, VariationRegion, VariationRegionList,
+use write_fonts::tables::{
+    layout::VariationIndex,
+    variations::{ItemVariationData, ItemVariationStore, VariationRegion, VariationRegionList},
 };
 
 /// A builder for the [ItemVariationStore].
@@ -208,9 +209,20 @@ impl VariationIndexRemapping {
         self.map.insert(from, to);
     }
 
-    #[cfg(test)]
     fn get(&self, from: DeltaKey) -> Option<DeltaKey> {
         self.map.get(&from).copied()
+    }
+
+    /// remap a variation index table to its final position
+    pub(crate) fn remap(&self, table: &mut VariationIndex) {
+        let key = DeltaKey {
+            outer: table.delta_set_outer_index,
+            inner: table.delta_set_inner_index,
+        };
+
+        let resolved = self.get(key).unwrap();
+        table.delta_set_outer_index = resolved.outer;
+        table.delta_set_inner_index = resolved.inner;
     }
 }
 


### PR DESCRIPTION
This implements that logic that goes through every item that may contain a reference to something in the ItemVariationStore, and replaces the temporary VariationIndex with the appropriate index in the compiled table.


Based on #185, which should go in first.