### PR TITLE
Correctly write empty value records

### DIFF
--- a/fea-rs/src/compile/lookups/gpos.rs
+++ b/fea-rs/src/compile/lookups/gpos.rs
@@ -265,8 +265,8 @@ impl Builder for ClassPairPosSubtable {
             .and_then(|val| val.values().next())
             .map(|(v1, v2)| {
                 write_gpos::Class2Record::new(
-                    empty_record_with_format(v1.format()),
-                    empty_record_with_format(v2.format()),
+                    ValueRecord::new().with_explicit_value_format(v1.format()),
+                    ValueRecord::new().with_explicit_value_format(v2.format()),
                 )
             })
             .unwrap();
@@ -293,35 +293,6 @@ impl Builder for ClassPairPosSubtable {
         }
         write_gpos::PairPos::format_2(coverage, class1def, class2def, out)
     }
-}
-
-fn empty_record_with_format(format: ValueFormat) -> ValueRecord {
-    let mut result = ValueRecord::default();
-    if format.contains(ValueFormat::X_PLACEMENT) {
-        result.x_placement = Some(0);
-    }
-    if format.contains(ValueFormat::Y_PLACEMENT) {
-        result.y_placement = Some(0);
-    }
-    if format.contains(ValueFormat::X_ADVANCE) {
-        result.x_advance = Some(0);
-    }
-    if format.contains(ValueFormat::Y_ADVANCE) {
-        result.y_advance = Some(0);
-    }
-    if format.intersects(
-        ValueFormat::X_PLACEMENT_DEVICE
-            | ValueFormat::Y_PLACEMENT_DEVICE
-            | ValueFormat::X_ADVANCE_DEVICE
-            | ValueFormat::Y_ADVANCE_DEVICE,
-    ) {
-        //FIXME idk here. I think we need to update code in write-fonts so that
-        // we take value format into account when deciding what we write,
-        // instead of just ignoring null values
-        panic!("writing explicit null offsets is currently broken, sorry")
-    }
-
-    result
 }
 
 #[derive(Clone, Debug, Default)]


### PR DESCRIPTION
This fixes a long standing (but previously unencountered) issue where we could not write empty value records containing device or variation index tables.

This required an upstream fix, which is now in place.