### PR TITLE
Use the PendingVariationIndex table instead of DeltaKey

### DIFF
--- a/fea-rs/src/compile/lookups.rs
+++ b/fea-rs/src/compile/lookups.rs
@@ -1098,8 +1098,8 @@ impl VariationIndexContainingLookup for ValueRecord {
 
 impl VariationIndexContainingLookup for DeviceOrVariationIndex {
     fn remap_variation_indices(&mut self, key_map: &VariationIndexRemapping) {
-        if let DeviceOrVariationIndex::VariationIndex(table) = self {
-            key_map.remap(table)
+        if let DeviceOrVariationIndex::PendingVariationIndex(table) = self {
+            *self = key_map.get(table.delta_set_id).unwrap().into();
         }
     }
 }


### PR DESCRIPTION
Just a draft for now, can be merged if https://github.com/googlefonts/fontations/pull/544 makes it into a release.

----

This is a more principled way of ensuring that we correctly remap all of these values before the final compilation pass.