### PR TITLE
Put clap & norad behind 'cli' feature

### DIFF
--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["test-data"]
 [dependencies]
 ansi_term = "0.12.1"
 smol_str = "0.2.0"
-norad = "0.11" # Used in the compile binary
+norad = { version = "0.11", optional = true } # Used in the compile binary
 write-fonts = { version = "0.13.0", features = ["read"] }
 chrono = "0.4.3"
 diff = { version = "0.1.12", optional = true }
@@ -23,13 +23,14 @@ rayon = { version = "1.6", optional = true }
 serde = { version = "1.0.147", features = ["derive"], optional = true }
 serde_json = {version = "1.0.87", optional = true }
 thiserror = "1.0.37"
-clap = { version = "4.0.32", features = ["derive"] }
+clap = { version = "4.0.32", features = ["derive"], optional = true }
 log = "0.4"
 env_logger = "0.10.0"
 indexmap = "2.0"
 
 [features]
-test = ["diff", "rayon", "serde", "serde_json"]
+test = ["diff", "rayon", "serde", "serde_json", "clap"]
+cli = ["norad", "clap"]
 
 [dev-dependencies]
 diff = "0.1.12"
@@ -45,8 +46,8 @@ harness = false
 [[bin]]
 name = "fea-rs"
 path = "src/bin/compile.rs"
+required-features = ["cli"]
 
-# this is an example so it can use dev-dependencies
 [[bin]]
 name = "ttx_test"
 required-features = ["test"]

--- a/fea-rs/src/bin/compile.rs
+++ b/fea-rs/src/bin/compile.rs
@@ -127,6 +127,7 @@ impl Args {
     }
 }
 
+#[cfg(feature = "norad")]
 impl From<norad::error::FontLoadError> for Error {
     fn from(src: norad::error::FontLoadError) -> Error {
         Error::Ufo(Box::new(src))

--- a/fea-rs/src/compile.rs
+++ b/fea-rs/src/compile.rs
@@ -6,8 +6,11 @@ use crate::{parse::ParseTree, Diagnostic, GlyphMap, GlyphName};
 
 use self::{
     compile_ctx::CompilationCtx,
-    error::{FontGlyphOrderError, GlyphOrderError, UfoGlyphOrderError},
+    error::{FontGlyphOrderError, GlyphOrderError},
 };
+
+#[cfg(feature = "norad")]
+use self::error::UfoGlyphOrderError;
 
 pub use compiler::Compiler;
 pub use opts::Opts;
@@ -43,13 +46,14 @@ pub(crate) fn validate(
     ctx.errors
 }
 
-static GLYPH_ORDER_KEY: &str = "public.glyphOrder";
-
 /// A helper function for extracting the glyph order from a UFO
 ///
 /// If the public.glyphOrder key is missing, or the glyphOrder is malformed,
 /// this will return `None`.
+#[cfg(feature = "norad")]
 pub fn get_ufo_glyph_order(font: &norad::Font) -> Result<GlyphMap, UfoGlyphOrderError> {
+    static GLYPH_ORDER_KEY: &str = "public.glyphOrder";
+
     font.lib
         .get(GLYPH_ORDER_KEY)
         .ok_or(UfoGlyphOrderError::KeyNotSet)?


### PR DESCRIPTION
These are only necessary if fea-rs is run as a binary from the command line, and we expect in the general case that it will be used as a library; no need to be compiling these two dependencies in that case.