### PR TITLE
bump write-fonts to 0.14.0

### DIFF
--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["test-data"]
 ansi_term = "0.12.1"
 smol_str = "0.2.0"
 norad = { version = "0.11", optional = true } # Used in the compile binary
-write-fonts = { version = "0.13.0", features = ["read"] }
+write-fonts = { version = "0.14.0", features = ["read"] }
 chrono = "0.4.3"
 diff = { version = "0.1.12", optional = true }
 rayon = { version = "1.6", optional = true }

--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fea-rs"
-version = "0.12.0"
+version = "0.13.0"
 license = "MIT/Apache-2.0"
 authors = ["Colin Rofls <colin@cmyr.net>"]
 description = "Tools for working with Adobe OpenType Feature files."


### PR DESCRIPTION
required to be able to depend on it from fontc, fixes a few issues with IUP optimization which should not affect fea-rs itself