### PR TITLE
Check for VarStore in GDEF when deciding to build

### DIFF
--- a/fea-rs/src/compile/tables/gdef.rs
+++ b/fea-rs/src/compile/tables/gdef.rs
@@ -143,6 +143,7 @@ impl GdefBuilder {
             && self.ligature_pos.is_empty()
             && self.mark_attach_class.is_empty()
             && self.mark_glyph_sets.is_empty()
+            && self.var_store.is_none()
     }
 }
 


### PR DESCRIPTION
we don't bother building a GDEF table if it will be empty, but we had not updated the is_empty check to consider the possibile existence of item variation data, and so we were not building GDEF in a situation where this subtable (and no others) was present.

We should add some integration tests that involve building this table, but that requires us to have some way to locally wire up the VariationModel.