### PR TITLE
Support axis location unit suffixes

### DIFF
--- a/fea-rs/src/compile.rs
+++ b/fea-rs/src/compile.rs
@@ -15,7 +15,7 @@ use self::error::UfoGlyphOrderError;
 pub use compiler::Compiler;
 pub use opts::Opts;
 pub use output::Compilation;
-pub use variations::{AxisInfo, VariationInfo};
+pub use variations::{AxisInfo, AxisLocation, VariationInfo};
 
 #[cfg(any(test, feature = "test"))]
 pub(crate) use variations::MockVariationInfo;

--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -1136,7 +1136,7 @@ impl<'a> CompilationCtx<'a> {
                     .map(|axis_value| {
                         (
                             axis_value.axis_tag().to_raw(),
-                            Fixed::from_i32(axis_value.value().parse_signed() as _),
+                            Fixed::from_f64(axis_value.value().value() as _),
                         )
                     })
                     .collect();

--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -1133,12 +1133,7 @@ impl<'a> CompilationCtx<'a> {
                 let user_loc = loc_value
                     .location()
                     .items()
-                    .map(|axis_value| {
-                        (
-                            axis_value.axis_tag().to_raw(),
-                            Fixed::from_f64(axis_value.value().value() as _),
-                        )
-                    })
+                    .map(|axis_value| (axis_value.axis_tag().to_raw(), axis_value.value().parse()))
                     .collect();
                 let value = loc_value.value().parse_signed();
                 (user_loc, value)

--- a/fea-rs/src/compile/validate.rs
+++ b/fea-rs/src/compile/validate.rs
@@ -1283,9 +1283,9 @@ impl<'a> ValidationCtx<'a> {
                     self.error(item.axis_tag().range(), "unknown axis");
                     continue;
                 };
-                let val = item.value().parse_signed() as i32;
-                let min = axis_info.min_value.to_i32();
-                let max = axis_info.max_value.to_i32();
+                let val = item.value().value() as f64;
+                let min = axis_info.min_value.to_f64();
+                let max = axis_info.max_value.to_f64();
                 if val < min {
                     self.error(
                         item.value().range(),

--- a/fea-rs/src/compile/variations.rs
+++ b/fea-rs/src/compile/variations.rs
@@ -21,6 +21,9 @@ pub trait VariationInfo {
     /// Return the normalized value for a user coordinate for the given axis.
     ///
     /// NOTE: This is only used for computing the normalized values for ConditionSets.
+    ///
+    /// NOTE: if unit suffixes become a thing, and ConditionSets remain a thing, then
+    /// this should use the same AxisLocation enum as below.
     fn normalize_coordinate(&self, axis_tag: Tag, value: Fixed) -> F2Dot14;
 
     /// Compute default & deltas for a set of locations and values in variation space.
@@ -29,14 +32,25 @@ pub trait VariationInfo {
     /// as a set of deltas suitable for inclusing in an `ItemVariationStore`.
     fn resolve_variable_metric(
         &self,
-        locations: &HashMap<UserLocation, i16>,
+        locations: &HashMap<Location, i16>,
     ) -> Result<(i16, Vec<(VariationRegion, i16)>), AnyError>;
 }
 
 type AnyError = Box<dyn std::error::Error>;
 
 // btreemap only because hashmap is not hashable
-type UserLocation = BTreeMap<Tag, Fixed>;
+type Location = BTreeMap<Tag, AxisLocation>;
+
+/// A location on an axis, in one of three coordinate spaces
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum AxisLocation {
+    /// A position in the user coordinate space
+    User(Fixed),
+    /// A position in the design coordinate space
+    Design(Fixed),
+    /// A normalized position
+    Normalized(Fixed),
+}
 
 /// Information about a paritcular axis in a variable font.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -111,7 +125,7 @@ impl VariationInfo for MockVariationInfo {
 
     fn resolve_variable_metric(
         &self,
-        _locations: &HashMap<UserLocation, i16>,
+        _locations: &HashMap<Location, i16>,
     ) -> Result<(i16, Vec<(VariationRegion, i16)>), Box<(dyn std::error::Error + 'static)>> {
         Ok(Default::default())
     }

--- a/fea-rs/src/parse/grammar/metrics.rs
+++ b/fea-rs/src/parse/grammar/metrics.rs
@@ -177,7 +177,30 @@ fn eat_location_item(parser: &mut Parser, recovery: TokenSet) -> bool {
     parser.in_node(AstKind::LocationSpecItemNode, |parser| {
         parser.eat_tag();
         parser.expect_recover(Kind::Eq, recovery.add(Kind::Comma));
-        parser.expect_recover(Kind::Number, recovery.add(Kind::Comma));
+        if !expect_axis_location(parser) {
+            parser.err_recover(
+                "expected axis location (number or float)",
+                recovery.add(Kind::Comma),
+            );
+        }
+    });
+    true
+}
+
+/// A float or integer, optionally followed by one of the suffixes 'u', 'c' or 'n'
+// e.g:
+// -50
+// 10001
+// -5u
+// 1.0n
+// -0.9d
+fn expect_axis_location(parser: &mut Parser) -> bool {
+    if !parser.matches(0, TokenSet::new(&[Kind::Number, Kind::Float])) {
+        return false;
+    }
+    parser.in_node(AstKind::AxisLocationNode, |parser| {
+        assert!(parser.eat(Kind::Number) || parser.eat(Kind::Float));
+        parser.eat(Kind::NumberSuffix);
     });
     true
 }

--- a/fea-rs/src/parse/grammar/metrics.rs
+++ b/fea-rs/src/parse/grammar/metrics.rs
@@ -187,7 +187,9 @@ fn eat_location_item(parser: &mut Parser, recovery: TokenSet) -> bool {
     true
 }
 
-/// A float or integer, optionally followed by one of the suffixes 'u', 'c' or 'n'
+/// A float or integer, optionally followed by one of the suffixes 'u', 'd' or 'n'
+/// NOTE: this is very experimental syntax, based on the discussion at
+/// <https://github.com/harfbuzz/boring-expansion-spec/issues/94#issuecomment-1608007111>
 // e.g:
 // -50
 // 10001

--- a/fea-rs/src/parse/lexer/lexeme.rs
+++ b/fea-rs/src/parse/lexer/lexeme.rs
@@ -34,6 +34,10 @@ pub enum Kind {
     HexEmpty, // naked 0x
     Float,
 
+    // Experimental
+    // a number or float + an optional suffix
+    NumberSuffix,
+
     Whitespace,
     Comment,
 
@@ -175,6 +179,7 @@ impl Kind {
                 | Self::Whitespace
                 | Self::NamedGlyphClass
                 | Self::Number
+                | Self::NumberSuffix
                 | Self::Cid
         )
     }
@@ -293,6 +298,7 @@ impl Kind {
             Self::Octal => AstKind::Octal,
             Self::Hex => AstKind::Hex,
             Self::Float => AstKind::Float,
+            Self::NumberSuffix => AstKind::NumberSuffix,
             Self::Whitespace => AstKind::Whitespace,
             Self::Semi => AstKind::Semi,
             Self::Colon => AstKind::Colon,
@@ -420,6 +426,7 @@ impl std::fmt::Display for Kind {
             Self::Hex => write!(f, "HEX"),
             Self::HexEmpty => write!(f, "HEX EMPTY"),
             Self::Float => write!(f, "FLOAT"),
+            Self::NumberSuffix => write!(f, "SUFFIX"),
             Self::Whitespace => write!(f, "WS"),
             Self::Semi => write!(f, ";"),
             Self::Colon => write!(f, ":"),

--- a/fea-rs/src/token_tree/token.rs
+++ b/fea-rs/src/token_tree/token.rs
@@ -20,6 +20,9 @@ pub enum Kind {
     HexEmpty, // naked 0x
     Float,
 
+    // experimental
+    NumberSuffix, // 'n' 'd' or 'u'
+
     Whitespace,
     Comment,
 
@@ -235,6 +238,7 @@ pub enum Kind {
     LocationValueNode,
     LocationSpecNode,
     LocationSpecItemNode,
+    AxisLocationNode, // a number or float + optional suffix
 
     TableNode,
     HeadTableNode,
@@ -316,6 +320,7 @@ impl std::fmt::Display for Kind {
             Self::Octal => write!(f, "OCT"),
             Self::Hex => write!(f, "HEX"),
             Self::HexEmpty => write!(f, "HEX EMPTY"),
+            Self::NumberSuffix => write!(f, "SUFFIX"),
             Self::Float => write!(f, "FLOAT"),
             Self::Whitespace => write!(f, "WS"),
             Self::Semi => write!(f, ";"),
@@ -490,6 +495,7 @@ impl std::fmt::Display for Kind {
             Self::LocationValueNode => write!(f, "LocationValueNode"),
             Self::LocationSpecNode => write!(f, "LocationSpecNode"),
             Self::LocationSpecItemNode => write!(f, "LocationSpecItemNode"),
+            Self::AxisLocationNode => write!(f, "AxisLocationNode"),
 
             Self::DeviceNode => write!(f, "DeviceNode"),
             Self::AnonBlockNode => write!(f, "AnonBlockNode"),

--- a/fea-rs/src/token_tree/typed.rs
+++ b/fea-rs/src/token_tree/typed.rs
@@ -278,6 +278,8 @@ ast_enum!(Metric {
     Scalar(Number),
     Variable(VariableMetric),
 });
+ast_node!(AxisLocation, Kind::AxisLocationNode);
+ast_token!(NumberSuffix, Kind::NumberSuffix);
 
 ast_node!(GdefClassDef, Kind::GdefClassDefNode);
 ast_node!(GdefClassDefEntry, Kind::GdefClassDefEntryNode);
@@ -1286,8 +1288,22 @@ impl LocationSpecItem {
         self.iter().find_map(Tag::cast).unwrap()
     }
 
-    pub(crate) fn value(&self) -> Number {
-        self.iter().skip(2).find_map(Number::cast).unwrap()
+    pub(crate) fn value(&self) -> AxisLocation {
+        self.iter().skip(2).find_map(AxisLocation::cast).unwrap()
+    }
+}
+
+impl AxisLocation {
+    pub(crate) fn value(&self) -> f32 {
+        let raw = self.iter().next().unwrap();
+        Number::cast(&raw)
+            .map(|num| num.parse_signed() as f32)
+            .or_else(|| Float::cast(&raw).map(|num| num.parse()))
+            .unwrap()
+    }
+
+    pub(crate) fn suffix(&self) -> Option<NumberSuffix> {
+        self.iter().find_map(NumberSuffix::cast)
     }
 }
 

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/variable_value_record_oob.ERR
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/variable_value_record_oob.ERR
@@ -1,11 +1,23 @@
-error: value below minimum allowed for axis (200)
+error: value exceeds expected range (200, 1000)
 in ./test-data/compile-tests/mini-latin/bad/variable_value_record_oob.fea at 1:24
   | 
 1 | valueRecordDef <0 (wght=100:-100 wght=1100:-150) 0 0> foo;
   |                         ^^^
 
-error: value greater than maximum allowed for axis (1000)
+error: value exceeds expected range (200, 1000)
 in ./test-data/compile-tests/mini-latin/bad/variable_value_record_oob.fea at 1:38
   | 
 1 | valueRecordDef <0 (wght=100:-100 wght=1100:-150) 0 0> foo;
   |                                       ^^^^
+
+error: normalized value should be in range (-1.0, 1.0)
+in ./test-data/compile-tests/mini-latin/bad/variable_value_record_oob.fea at 2:24
+  | 
+2 | valueRecordDef <0 (wght=-1.2n:-100 wght=5n:-150) 0 0> boo;
+  |                         ^^^^^
+
+error: normalized value should be in range (-1.0, 1.0)
+in ./test-data/compile-tests/mini-latin/bad/variable_value_record_oob.fea at 2:40
+  | 
+2 | valueRecordDef <0 (wght=-1.2n:-100 wght=5n:-150) 0 0> boo;
+  |                                         ^^

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/variable_value_record_oob.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/variable_value_record_oob.fea
@@ -1,1 +1,2 @@
 valueRecordDef <0 (wght=100:-100 wght=1100:-150) 0 0> foo;
+valueRecordDef <0 (wght=-1.2n:-100 wght=5n:-150) 0 0> boo;

--- a/fea-rs/test-data/parse-tests/bad/suffix_metrics.ERR
+++ b/fea-rs/test-data/parse-tests/bad/suffix_metrics.ERR
@@ -1,0 +1,11 @@
+error: Expected : found ID
+in ./test-data/parse-tests/bad/suffix_metrics.fea at 2:20
+  | 
+2 |     pos p (wght=1000f:-100 wght=200D:0);
+  |                     ^^^^^^
+
+error: Expected : found ID
+in ./test-data/parse-tests/bad/suffix_metrics.fea at 2:35
+  | 
+2 |     pos p (wght=1000f:-100 wght=200D:0);
+  |                                    ^^^

--- a/fea-rs/test-data/parse-tests/bad/suffix_metrics.fea
+++ b/fea-rs/test-data/parse-tests/bad/suffix_metrics.fea
@@ -1,0 +1,3 @@
+feature kern {
+    pos p (wght=1000f:-100 wght=200D:0);
+} kern;

--- a/fea-rs/test-data/parse-tests/good/suffix_metrics.PARSE_TREE
+++ b/fea-rs/test-data/parse-tests/good/suffix_metrics.PARSE_TREE
@@ -1,0 +1,84 @@
+FILE@[0; 111)
+    FeatureNode@[0; 110)
+      FeatureKw@0 "feature"
+      WS@7 " "
+      Tag@8 "kern"
+      WS@12 " "
+      {@13 "{"
+      WS@14 "\n    "
+        GposType1@[19; 55)
+          PosKw@19 "pos"
+          WS@22 " "
+          GlyphName@23 "p"
+          WS@24 " "
+            ValueRecordNode@[25; 54)
+                VariableMetricNode@[25; 54)
+                  (@25 "("
+                    LocationValueNode@[26; 41)
+                        LocationSpecNode@[26; 36)
+                            LocationSpecItemNode@[26; 36)
+                              Tag@26 "wght"
+                              =@30 "="
+                                AxisLocationNode@[31; 36)
+                                  NUM@31 "1000"
+                                  SUFFIX@35 "u"
+                      :@36 ":"
+                      NUM@37 "-100"
+                  WS@41 " "
+                    LocationValueNode@[42; 53)
+                        LocationSpecNode@[42; 51)
+                            LocationSpecItemNode@[42; 51)
+                              Tag@42 "wght"
+                              =@46 "="
+                                AxisLocationNode@[47; 51)
+                                  NUM@47 "200"
+                                  SUFFIX@50 "d"
+                      :@51 ":"
+                      NUM@52 "0"
+                  )@53 ")"
+          ;@54 ";"
+      WS@55 "\n    "
+        GposType1@[60; 102)
+          PosKw@60 "pos"
+          WS@63 " "
+          GlyphName@64 "d"
+          WS@65 " "
+            ValueRecordNode@[66; 101)
+                VariableMetricNode@[66; 101)
+                  (@66 "("
+                    LocationValueNode@[67; 77)
+                        LocationSpecNode@[67; 75)
+                            LocationSpecItemNode@[67; 75)
+                              Tag@67 "blah"
+                              =@71 "="
+                                AxisLocationNode@[72; 75)
+                                  NUM@72 "-1"
+                                  SUFFIX@74 "n"
+                      :@75 ":"
+                      NUM@76 "5"
+                  WS@77 " "
+                    LocationValueNode@[78; 100)
+                        LocationSpecNode@[78; 96)
+                            LocationSpecItemNode@[78; 86)
+                              Tag@78 "blah"
+                              =@82 "="
+                                AxisLocationNode@[83; 86)
+                                  FLOAT@83 "0.5"
+                          ,@86 ","
+                            LocationSpecItemNode@[87; 96)
+                              Tag@87 "rah"
+                              =@90 "="
+                                AxisLocationNode@[91; 96)
+                                  FLOAT@91 "-0.3"
+                                  SUFFIX@95 "n"
+                      :@96 ":"
+                      WS@97 " "
+                      NUM@98 "-9"
+                  )@100 ")"
+          ;@101 ";"
+      WS@102 "\n"
+      }@103 "}"
+      WS@104 " "
+      Tag@105 "kern"
+      ;@109 ";"
+  WS@110 "\n"

--- a/fea-rs/test-data/parse-tests/good/suffix_metrics.fea
+++ b/fea-rs/test-data/parse-tests/good/suffix_metrics.fea
@@ -1,0 +1,4 @@
+feature kern {
+    pos p (wght=1000u:-100 wght=200d:0);
+    pos d (blah=-1n:5 blah=0.5,rah=-0.3n: -9);
+} kern;

--- a/fea-rs/test-data/parse-tests/good/variable_anchor.PARSE_TREE
+++ b/fea-rs/test-data/parse-tests/good/variable_anchor.PARSE_TREE
@@ -12,7 +12,8 @@ FILE@[0; 152)
                         LocationSpecItemNode@[13; 21)
                           Tag@13 "wght"
                           =@17 "="
-                          NUM@18 "200"
+                            AxisLocationNode@[18; 21)
+                              NUM@18 "200"
                   :@21 ":"
                   NUM@22 "12"
               WS@24 " "
@@ -21,7 +22,8 @@ FILE@[0; 152)
                         LocationSpecItemNode@[25; 33)
                           Tag@25 "wght"
                           =@29 "="
-                          NUM@30 "900"
+                            AxisLocationNode@[30; 33)
+                              NUM@30 "900"
                   :@33 ":"
                   NUM@34 "22"
               WS@36 " "
@@ -30,12 +32,14 @@ FILE@[0; 152)
                         LocationSpecItemNode@[37; 45)
                           Tag@37 "wdth"
                           =@41 "="
-                          NUM@42 "150"
+                            AxisLocationNode@[42; 45)
+                              NUM@42 "150"
                       ,@45 ","
                         LocationSpecItemNode@[46; 54)
                           Tag@46 "wght"
                           =@50 "="
-                          NUM@51 "900"
+                            AxisLocationNode@[51; 54)
+                              NUM@51 "900"
                   :@54 ":"
                   NUM@55 "42"
               )@57 ")"
@@ -54,7 +58,8 @@ FILE@[0; 152)
                         LocationSpecItemNode@[76; 84)
                           Tag@76 "wght"
                           =@80 "="
-                          NUM@81 "100"
+                            AxisLocationNode@[81; 84)
+                              NUM@81 "100"
                   :@84 ":"
                   NUM@85 "0"
               WS@86 " "
@@ -63,7 +68,8 @@ FILE@[0; 152)
                         LocationSpecItemNode@[87; 95)
                           Tag@87 "wght"
                           =@91 "="
-                          NUM@92 "900"
+                            AxisLocationNode@[92; 95)
+                              NUM@92 "900"
                   :@95 ":"
                   NUM@96 "5"
               )@97 ")"
@@ -75,7 +81,8 @@ FILE@[0; 152)
                         LocationSpecItemNode@[100; 108)
                           Tag@100 "wght"
                           =@104 "="
-                          NUM@105 "200"
+                            AxisLocationNode@[105; 108)
+                              NUM@105 "200"
                   :@108 ":"
                   NUM@109 "12"
               WS@111 " "
@@ -84,7 +91,8 @@ FILE@[0; 152)
                         LocationSpecItemNode@[112; 120)
                           Tag@112 "wght"
                           =@116 "="
-                          NUM@117 "900"
+                            AxisLocationNode@[117; 120)
+                              NUM@117 "900"
                   :@120 ":"
                   NUM@121 "22"
               WS@123 " "
@@ -93,12 +101,14 @@ FILE@[0; 152)
                         LocationSpecItemNode@[124; 132)
                           Tag@124 "wdth"
                           =@128 "="
-                          NUM@129 "150"
+                            AxisLocationNode@[129; 132)
+                              NUM@129 "150"
                       ,@132 ","
                         LocationSpecItemNode@[133; 141)
                           Tag@133 "wght"
                           =@137 "="
-                          NUM@138 "900"
+                            AxisLocationNode@[138; 141)
+                              NUM@138 "900"
                   :@141 ":"
                   NUM@142 "42"
               )@144 ")"

--- a/fea-rs/test-data/parse-tests/good/variable_metrics.PARSE_TREE
+++ b/fea-rs/test-data/parse-tests/good/variable_metrics.PARSE_TREE
@@ -21,7 +21,8 @@ FILE@[0; 204)
                             LocationSpecItemNode@[28; 37)
                               Tag@28 "wght"
                               =@32 "="
-                              NUM@33 "1000"
+                                AxisLocationNode@[33; 37)
+                                  NUM@33 "1000"
                       :@37 ":"
                       NUM@38 "-100"
                   WS@42 " "
@@ -30,7 +31,8 @@ FILE@[0; 204)
                             LocationSpecItemNode@[43; 51)
                               Tag@43 "wght"
                               =@47 "="
-                              NUM@48 "200"
+                                AxisLocationNode@[48; 51)
+                                  NUM@48 "200"
                       :@51 ":"
                       NUM@52 "0"
                   )@53 ")"
@@ -51,7 +53,8 @@ FILE@[0; 204)
                             LocationSpecItemNode@[69; 77)
                               Tag@69 "wght"
                               =@73 "="
-                              NUM@74 "200"
+                                AxisLocationNode@[74; 77)
+                                  NUM@74 "200"
                       :@77 ":"
                       NUM@78 "-100"
                   WS@82 " "
@@ -60,7 +63,8 @@ FILE@[0; 204)
                             LocationSpecItemNode@[83; 91)
                               Tag@83 "wght"
                               =@87 "="
-                              NUM@88 "900"
+                                AxisLocationNode@[88; 91)
+                                  NUM@88 "900"
                       :@91 ":"
                       NUM@92 "-150"
                   WS@96 " "
@@ -69,12 +73,14 @@ FILE@[0; 204)
                             LocationSpecItemNode@[97; 105)
                               Tag@97 "wdth"
                               =@101 "="
-                              NUM@102 "150"
+                                AxisLocationNode@[102; 105)
+                                  NUM@102 "150"
                           ,@105 ","
                             LocationSpecItemNode@[106; 114)
                               Tag@106 "wght"
                               =@110 "="
-                              NUM@111 "900"
+                                AxisLocationNode@[111; 114)
+                                  NUM@111 "900"
                       :@114 ":"
                       NUM@115 "-120"
                   )@119 ")"
@@ -102,7 +108,8 @@ FILE@[0; 204)
                         LocationSpecItemNode@[162; 170)
                           Tag@162 "blah"
                           =@166 "="
-                          NUM@167 "100"
+                            AxisLocationNode@[167; 170)
+                              NUM@167 "100"
                   :@170 ":"
                   NUM@171 "5"
               WS@172 " "
@@ -111,12 +118,14 @@ FILE@[0; 204)
                         LocationSpecItemNode@[173; 181)
                           Tag@173 "blah"
                           =@177 "="
-                          NUM@178 "400"
+                            AxisLocationNode@[178; 181)
+                              NUM@178 "400"
                       ,@181 ","
                         LocationSpecItemNode@[182; 189)
                           Tag@182 "rah"
                           =@185 "="
-                          NUM@186 "300"
+                            AxisLocationNode@[186; 189)
+                              NUM@186 "300"
                   :@189 ":"
                   WS@190 " "
                   NUM@191 "-9"

--- a/fea-rs/test-data/parse-tests/good/variable_value_record.PARSE_TREE
+++ b/fea-rs/test-data/parse-tests/good/variable_value_record.PARSE_TREE
@@ -13,7 +13,8 @@ FILE@[0; 81)
                         LocationSpecItemNode@[19; 27)
                           Tag@19 "wght"
                           =@23 "="
-                          NUM@24 "200"
+                            AxisLocationNode@[24; 27)
+                              NUM@24 "200"
                   :@27 ":"
                   NUM@28 "-100"
               WS@32 " "
@@ -22,7 +23,8 @@ FILE@[0; 81)
                         LocationSpecItemNode@[33; 41)
                           Tag@33 "wght"
                           =@37 "="
-                          NUM@38 "900"
+                            AxisLocationNode@[38; 41)
+                              NUM@38 "900"
                   :@41 ":"
                   NUM@42 "-150"
               WS@46 " "
@@ -31,12 +33,14 @@ FILE@[0; 81)
                         LocationSpecItemNode@[47; 55)
                           Tag@47 "wdth"
                           =@51 "="
-                          NUM@52 "150"
+                            AxisLocationNode@[52; 55)
+                              NUM@52 "150"
                       ,@55 ","
                         LocationSpecItemNode@[56; 64)
                           Tag@56 "wght"
                           =@60 "="
-                          NUM@61 "900"
+                            AxisLocationNode@[61; 64)
+                              NUM@61 "900"
                   :@64 ":"
                   NUM@65 "-120"
               )@69 ")"


### PR DESCRIPTION
This was much less painful than I had expected! When I had been thinking about this change I was thinking that the unit suffixes would be applied to the metric values themselves, which are used all over the place (including in non-variable contexts) but in reality the suffixes only apply to the values for the axis positions, which means that we can parse them differently without that impacting the parsing of anything else in the codebase.

@rsheeter this shouldn't require much change for you; the main difference is that instead of using a 'user location' we now use a location where the values are an enum with user/design/normalized variants.