### PR TITLE
Add expected diff to fonttools test spec5f_ii_4.fea

### DIFF
--- a/fea-rs/test-data/fonttools-tests/spec5f_ii_4.expected_diff
+++ b/fea-rs/test-data/fonttools-tests/spec5f_ii_4.expected_diff
@@ -1,0 +1,25 @@
+# generated automatically by fea-rs
+# this file represents an acceptable difference between the output of
+# fonttools and the output of fea-rs for a given input.
+#
+# # Note: we generate two different subtables here, which is a more efficient
+# representation than what fonttools does.
+L247
+>          <!-- SubTableCount=1 -->
+L247
+<          <!-- SubTableCount=2 -->
+L250
+<            <Substitution in="T_h" out="T_h.swash"/>
+<            <Substitution in="a" out="a.end"/>
+<            <Substitution in="e" out="e.end"/>
+<            <Substitution in="m" out="m.begin"/>
+<            <Substitution in="z" out="z.end"/>
+<          </SingleSubst>
+<          <SingleSubst index="1">
+L276
+>            <Substitution in="T_h" out="T_h.swash"/>
+L283
+>            <Substitution in="a" out="a.end"/>
+>            <Substitution in="e" out="e.end"/>
+>            <Substitution in="m" out="m.begin"/>
+>            <Substitution in="z" out="z.end"/>


### PR DESCRIPTION
After investigating, this is a situation where we are performing an optimization that fonttools isn't, which is fine.

Filed in fonttools to make sure I'm not missing something: https://github.com/fonttools/fonttools/issues/3259