### PR TITLE
More efficient generation of anonymous lookups

### DIFF
--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -643,8 +643,8 @@ impl<'a> CompilationCtx<'a> {
                     .collect::<Vec<_>>();
                 let replacement = self.resolve_glyph(&rule.replacement_glyphs().next().unwrap());
                 let lookup = self.ensure_current_lookup_type(Kind::GsubType6);
-                //FIXME: we should check that the whole sequence is not present the
-                //lookup before adding..
+                //FIXME: we should check that the whole sequence is not present
+                // in the lookup before adding.. (https://github.com/cmyr/fea-rs/issues/207)
                 let mut to_return = None;
                 for target in sequence_enumerator(&target) {
                     to_return = Some(


### PR DESCRIPTION
This resolves one more outstanding diff with fonttools, which is represented in the 'bug514.fea' test case; when adding anonymous rules we would only ever check the most recently added anonymous lookup to see if rules could be inserted there. With this change we will now check all active anonymous lookups, which means we should create fewer lookups and have fewer redundencies in them.