### PR TITLE
Minor refactor of contextual lookup compilation

### DIFF
--- a/fea-rs/src/bin/ttx_test.rs
+++ b/fea-rs/src/bin/ttx_test.rs
@@ -10,6 +10,7 @@ static TEST_DATA: &str = "./fea-rs/test-data/fonttools-tests";
 static WIP_DIFF_DIR: &str = "./wip";
 
 fn main() {
+    env_logger::init();
     let args = Args::parse();
 
     let results = ttx::run_all_tests(TEST_DATA, args.test_filter.as_ref());


### PR DESCRIPTION
This moves a few things around, adds logging, and minorly improves the efficiency of compilation in the case where only one table format is possible (by not bothering to precheck the sizes in this case.)