### PR TITLE
[ci] Remove code to ignore certain test cases in CI

### DIFF
--- a/fea-rs/src/util/ttx.rs
+++ b/fea-rs/src/util/ttx.rs
@@ -37,10 +37,6 @@ static IGNORED_TESTS: &[&str] = &[
     "variable_scalar_valuerecord.fea",
 ];
 
-// these tests are failing and need to be investigated, but I still want to
-// pass CI for the time being.
-static IGNORED_IN_CI_ONLY: &[&str] = &["bug514.fea", "spec5f_ii_3.fea", "spec5f_ii_4.fea"];
-
 /// An environment variable that can be set to specify where to write generated files.
 ///
 /// This can be set during debugging if you want to inspect the generated files.
@@ -197,18 +193,7 @@ fn iter_compile_tests<'a>(
 }
 
 fn should_run_test(path: &str) -> bool {
-    // https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
-    let ci_var = std::env::var_os("CI").unwrap_or_default();
-    let in_ci = ci_var == "true";
-
-    if IGNORED_TESTS.contains(&path) {
-        return false;
-    }
-    if in_ci && IGNORED_IN_CI_ONLY.contains(&path) {
-        return false;
-    }
-
-    true
+    !IGNORED_TESTS.contains(&path)
 }
 
 /// Iterate over all the files in a directory with the 'fea' suffix


### PR DESCRIPTION
This can go in once #212 #208 and #206 are merged.

----

This was gross; the idea was that we had certain known failures in the fonttools test suite, but we wanted to run the rest of those cases for the time being, so would explicitly check to see if we were in CI when running tests.

This was probably too cute. In any case there are now PRs up that resolve these outstanding failures, so we can get rid of this.