### PR TITLE
Change format size log level to 'trace'

### DIFF
--- a/fea-rs/src/compile/lookups/contextual.rs
+++ b/fea-rs/src/compile/lookups/contextual.rs
@@ -701,7 +701,7 @@ fn pick_best_format<T: FontWrite + Validate>(tables: [Option<T>; 3]) -> T {
         .enumerate()
         .filter_map(|(i, table)| table.map(|table| (i + 1, compute_size(&table), table)))
         .inspect(|(i, size, _table)| {
-            log::debug!("format {i} size {size:?}");
+            log::trace!("format {i} size {size:?}");
         })
         .min_by_key(|(_, size, _)| *size)
         .unwrap()


### PR DESCRIPTION
This was cluttering up logs when I was debugging pairpos2 splitting.