### PR TITLE
bump write-fonts to 0.17.0

### DIFF
--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["test-data"]
 ansi_term = "0.12.1"
 smol_str = "0.2.0"
 norad = { version = "0.12", optional = true } # Used in the compile binary
-write-fonts = { version = "0.16.0", features = ["read"] }
+write-fonts = { version = "0.17.0", features = ["read"] }
 chrono = "0.4.3"
 diff = { version = "0.1.12", optional = true }
 rayon = { version = "1.6", optional = true }


### PR DESCRIPTION
Not directly needed by fea-rs but fontc (user of fea-rs) needs it and can't update otherwise