### PR TITLE
bump minor version to 0.18

### DIFF
--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fea-rs"
-version = "0.17.0"
+version = "0.18.0"
 license = "MIT/Apache-2.0"
 authors = ["Colin Rofls <colin@cmyr.net>"]
 description = "Tools for working with Adobe OpenType Feature files."


### PR DESCRIPTION
bump minor because write-fonts was bumped minor

No actual changes besides bumping write-fonts itself