### PR TITLE
Allow specifying variation info at the CLI

### DIFF
--- a/fea-rs/src/compile.rs
+++ b/fea-rs/src/compile.rs
@@ -17,8 +17,8 @@ pub use opts::Opts;
 pub use output::Compilation;
 pub use variations::{AxisInfo, AxisLocation, VariationInfo};
 
-#[cfg(any(test, feature = "test"))]
-pub(crate) use variations::MockVariationInfo;
+#[cfg(any(test, feature = "test", feature = "cli"))]
+pub use variations::MockVariationInfo;
 
 mod compile_ctx;
 mod compiler;


### PR DESCRIPTION
This will make it easier for us to debug and profile fontc, by letting us run feature compilation in isolation, on our real inputs.

axis info can be specified in a file, where each (non blank, non commented) line contains a tag and three numbers.


I thought about various ways this could be specified, and this just felt like the simplest, although I don't particularly like it.

The idea here is that (as discussed with @rsheeter at some point) is that it would be nice for both profiling and debugging fontc if we could dump out our generated fea and our axis info and then run the feature compiler directly.