### PR TITLE
Public feature builder api

### DIFF
--- a/fea-rs/src/common.rs
+++ b/fea-rs/src/common.rs
@@ -3,6 +3,7 @@
 use std::fmt::{Display, Formatter};
 
 use smol_str::SmolStr;
+use write_fonts::tables::gpos::AnchorTable;
 pub use write_fonts::types::GlyphId;
 
 mod glyph_class;
@@ -34,6 +35,11 @@ pub enum GlyphIdent {
     Name(GlyphName),
     /// a CID
     Cid(u16),
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct MarkClass {
+    pub(crate) members: Vec<(GlyphClass, Option<AnchorTable>)>,
 }
 
 impl<T: Into<GlyphName>> From<T> for GlyphIdent {

--- a/fea-rs/src/common/glyph_class.rs
+++ b/fea-rs/src/common/glyph_class.rs
@@ -29,15 +29,16 @@ impl<'a> std::iter::IntoIterator for &'a GlyphClass {
 }
 
 impl GlyphClass {
-    pub fn items(&self) -> &[GlyphId] {
+    pub(crate) fn items(&self) -> &[GlyphId] {
         &self.0
     }
 
+    /// Return a new, empty glyph class
     pub fn empty() -> Self {
         Self(Rc::new([]))
     }
 
-    pub fn sort_and_dedupe(&self) -> GlyphClass {
+    pub(crate) fn sort_and_dedupe(&self) -> GlyphClass {
         //idfk I guess this is fine
         let mut vec = self.0.iter().cloned().collect::<Vec<_>>();
         vec.sort_unstable();
@@ -45,11 +46,11 @@ impl GlyphClass {
         GlyphClass(vec.into())
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = GlyphId> + '_ {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = GlyphId> + '_ {
         self.items().iter().copied()
     }
 
-    pub fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         self.0.len()
     }
 }

--- a/fea-rs/src/compile.rs
+++ b/fea-rs/src/compile.rs
@@ -13,6 +13,9 @@ use self::{
 use self::error::UfoGlyphOrderError;
 
 pub use compiler::Compiler;
+pub use feature_writer::{FeatureBuilder, FeatureProvider};
+pub use language_system::LanguageSystem;
+pub use lookups::{FeatureKey, LookupId, PairPosBuilder};
 pub use opts::Opts;
 pub use output::Compilation;
 pub use variations::{AxisInfo, AxisLocation, VariationInfo};
@@ -23,6 +26,7 @@ pub(crate) use variations::MockVariationInfo;
 mod compile_ctx;
 mod compiler;
 pub mod error;
+mod feature_writer;
 mod features;
 mod glyph_range;
 mod language_system;

--- a/fea-rs/src/compile.rs
+++ b/fea-rs/src/compile.rs
@@ -15,7 +15,10 @@ use self::error::UfoGlyphOrderError;
 pub use compiler::Compiler;
 pub use feature_writer::{FeatureBuilder, FeatureProvider};
 pub use language_system::LanguageSystem;
-pub use lookups::{FeatureKey, LookupId, PairPosBuilder};
+pub use lookups::{
+    FeatureKey, LookupId, MarkToBaseBuilder, MarkToMarkBuilder, PairPosBuilder,
+    PreviouslyAssignedClass,
+};
 pub use opts::Opts;
 pub use output::Compilation;
 pub use variations::{AxisInfo, AxisLocation, VariationInfo};

--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -244,10 +244,20 @@ impl<'a> CompilationCtx<'a> {
             return;
         };
 
-        let mut builder =
-            FeatureBuilder::new(&self.default_lang_systems, self.mark_filter_sets.len());
+        let mut builder = FeatureBuilder::new(
+            &self.default_lang_systems,
+            &mut self.tables,
+            self.mark_filter_sets.len(),
+        );
         writer.add_features(&mut builder);
-        todo!("now actually try to merge in the generated features?");
+
+        // now we need to merge in the newly generated features.
+        let id_map = self.lookups.merge_external_lookups(builder.lookups);
+        builder
+            .features
+            .values_mut()
+            .for_each(|feat| feat.base.iter_mut().for_each(|id| *id = id_map.get(*id)));
+        self.features.merge_external_features(builder.features);
     }
 
     /// Infer/update GDEF table as required.

--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -965,11 +965,11 @@ impl<'a> CompilationCtx<'a> {
                             .as_ref()
                             .expect("no null anchors in mark-to-mark (check validation)");
                         for glyph in glyphs.iter() {
-                            subtable.insert_mark(glyph, class_name.clone(), anchor.clone())?;
+                            subtable.insert_mark1(glyph, class_name.clone(), anchor.clone())?;
                         }
                     }
                     for base in base_ids.iter() {
-                        subtable.insert_base(
+                        subtable.insert_mark2(
                             base,
                             class_name,
                             base_anchor

--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -22,7 +22,7 @@ use write_fonts::{
 };
 
 use crate::{
-    common::{GlyphClass, GlyphId, GlyphOrClass},
+    common::{GlyphClass, GlyphId, GlyphOrClass, MarkClass},
     parse::SourceMap,
     token_tree::{
         typed::{self, AstNode},
@@ -33,6 +33,7 @@ use crate::{
 };
 
 use super::{
+    feature_writer::{FeatureBuilder, FeatureProvider},
     features::{
         AaltFeature, ActiveFeature, AllFeatures, ConditionSetMap, CvParams, SizeFeature,
         SpecialVerticalFeatureState,
@@ -67,6 +68,7 @@ pub struct CompilationCtx<'a> {
     reverse_glyph_map: BTreeMap<GlyphId, GlyphIdent>,
     source_map: &'a SourceMap,
     variation_info: Option<&'a dyn VariationInfo>,
+    feature_writer: Option<&'a dyn FeatureProvider>,
     /// Any errors or warnings generated during compilation.
     pub errors: Vec<Diagnostic>,
     /// Stores any [specified table values][tables] in the input FEA.
@@ -92,22 +94,19 @@ pub struct CompilationCtx<'a> {
     mark_filter_sets: HashMap<GlyphClass, FilterSetId>,
 }
 
-#[derive(Clone, Debug, Default)]
-struct MarkClass {
-    members: Vec<(GlyphClass, Option<AnchorTable>)>,
-}
-
 impl<'a> CompilationCtx<'a> {
     pub(crate) fn new(
         glyph_map: &'a GlyphMap,
         source_map: &'a SourceMap,
         variation_info: Option<&'a dyn VariationInfo>,
+        feature_writer: Option<&'a dyn FeatureProvider>,
     ) -> Self {
         CompilationCtx {
             glyph_map,
             reverse_glyph_map: glyph_map.reverse_map(),
             source_map,
             variation_info,
+            feature_writer,
             errors: Vec::new(),
             tables: Tables::default(),
             default_lang_systems: Default::default(),
@@ -160,6 +159,11 @@ impl<'a> CompilationCtx<'a> {
                 self.error(span, format!("unhandled top-level item: '{}'", item.kind()));
             }
         }
+
+        // NOTE: this is the easiest place for us to do this, but we
+        // could potentially be more performant by running this in parallel,
+        // immediately after parsing?
+        self.run_feature_writer_if_present();
 
         self.finalize_gdef_table();
         self.features
@@ -233,6 +237,17 @@ impl<'a> CompilationCtx<'a> {
             gsub,
             gpos,
         })
+    }
+
+    fn run_feature_writer_if_present(&mut self) {
+        let Some(writer) = self.feature_writer else {
+            return;
+        };
+
+        let mut builder =
+            FeatureBuilder::new(&self.default_lang_systems, self.mark_filter_sets.len());
+        writer.add_features(&mut builder);
+        todo!("now actually try to merge in the generated features?");
     }
 
     /// Infer/update GDEF table as required.

--- a/fea-rs/src/compile/feature_writer.rs
+++ b/fea-rs/src/compile/feature_writer.rs
@@ -15,7 +15,7 @@ use super::{
     features::FeatureLookups,
     language_system::{DefaultLanguageSystems, LanguageSystem},
     lookups::{FeatureKey, FilterSetId, LookupBuilder, LookupId, PositionLookup},
-    tables::Tables,
+    tables::{GdefBuilder, Tables},
 };
 
 /// A trait that can be implemented by the client to do custom feature writing.
@@ -70,6 +70,11 @@ impl<'a> FeatureBuilder<'a> {
     /// An iterator over the default language systems registered in the FEA
     pub fn language_systems(&self) -> impl Iterator<Item = LanguageSystem> + 'a {
         self.language_systems.iter()
+    }
+
+    /// If the FEA text contained an explicit GDEF table block, return its contents
+    pub fn gdef(&self) -> Option<&GdefBuilder> {
+        self.tables.gdef.as_ref()
     }
 
     /// Define a new mark class, for use in mark-base and mark-mark rules.

--- a/fea-rs/src/compile/feature_writer.rs
+++ b/fea-rs/src/compile/feature_writer.rs
@@ -1,0 +1,132 @@
+//! API for the client to manually add additional features
+
+use std::collections::{BTreeMap, HashMap};
+
+use smol_str::SmolStr;
+use write_fonts::tables::{gpos::AnchorTable, layout::LookupFlag};
+
+use crate::common::{GlyphClass, MarkClass};
+
+use super::{
+    features::FeatureLookups,
+    language_system::{DefaultLanguageSystems, LanguageSystem},
+    lookups::{FeatureKey, FilterSetId, LookupBuilder, LookupId, PositionLookup},
+};
+
+/// A trait that can be implemented by the client to do custom feature writing.
+pub trait FeatureProvider {
+    /// The client can write additional features into the provided builder
+    fn add_features(&self, builder: &mut FeatureBuilder);
+}
+
+/// A structure that allows client code to add additional features to the compilation.
+pub struct FeatureBuilder<'a> {
+    pub(crate) language_systems: &'a DefaultLanguageSystems,
+    pub(crate) lookups: Vec<PositionLookup>,
+    pub(crate) features: BTreeMap<FeatureKey, FeatureLookups>,
+    pub(crate) mark_classes: HashMap<SmolStr, MarkClass>,
+    mark_filter_sets: HashMap<GlyphClass, FilterSetId>,
+    // because there may already be defined filter sets from the root fea
+    filter_set_id_start: usize,
+}
+
+pub trait GposSubtableBuilder: Sized {
+    #[doc(hidden)]
+    fn to_pos_lookup(
+        flags: LookupFlag,
+        filter_set: Option<FilterSetId>,
+        subtables: Vec<Self>,
+    ) -> ExternalGposLookup;
+}
+
+/// An externally created GPOS lookup.
+///
+/// This only exists so that we can avoid making our internal types `pub`.
+pub struct ExternalGposLookup(PositionLookup);
+
+impl<'a> FeatureBuilder<'a> {
+    pub(crate) fn new(
+        language_systems: &'a DefaultLanguageSystems,
+        filter_set_id_start: usize,
+    ) -> Self {
+        Self {
+            language_systems,
+            lookups: Default::default(),
+            features: Default::default(),
+            mark_classes: Default::default(),
+            mark_filter_sets: Default::default(),
+            filter_set_id_start,
+        }
+    }
+
+    /// An iterator over the default language systems registered in the FEA
+    pub fn language_systems(&self) -> impl Iterator<Item = LanguageSystem> + 'a {
+        self.language_systems.iter()
+    }
+
+    /// Define a new mark class, for use in mark-base and mark-mark rules.
+    ///
+    /// TODO: do we want to ensure there are no redefinitions? do we want
+    /// return an error? do we want to uphold any other invariants?
+    ///
+    /// ALSO: mark class IDs depend on definition order in the source.
+    /// I have no idea how best to approximate that in this API :/
+    pub fn define_mark_class(
+        &mut self,
+        class_name: impl Into<SmolStr>,
+        members: Vec<(GlyphClass, Option<AnchorTable>)>,
+    ) {
+        self.mark_classes
+            .insert(class_name.into(), MarkClass { members });
+    }
+
+    /// Create a new lookup.
+    ///
+    /// The `LookupId` that is returned can then be included in features via
+    /// the [`add_feature`] method.
+    pub fn add_lookup<T: GposSubtableBuilder>(
+        &mut self,
+        flags: LookupFlag,
+        filter_set: Option<GlyphClass>,
+        subtables: Vec<T>,
+    ) -> LookupId {
+        let filter_set_id = filter_set.map(|cls| self.get_filter_set_id(cls));
+        let lookup = T::to_pos_lookup(flags, filter_set_id, subtables);
+        let next_id = self.lookups.len();
+        self.lookups.push(lookup.0);
+        LookupId::External(next_id)
+    }
+
+    /// Create a new feature, registered for a particular language system.
+    ///
+    /// The caller must call this method once for each language system under
+    /// which a feature is to be registered.
+    pub fn add_feature(&mut self, key: FeatureKey, lookups: Vec<LookupId>) {
+        self.features.entry(key).or_default().base = lookups;
+    }
+
+    fn get_filter_set_id(&mut self, cls: GlyphClass) -> FilterSetId {
+        let next_id = self.filter_set_id_start + self.mark_filter_sets.len();
+        //.expect("too many filter sets");
+        *self.mark_filter_sets.entry(cls).or_insert_with(|| {
+            next_id
+                .try_into()
+                // is this in any way an expected error condition?
+                .expect("too many filter sets?")
+        })
+    }
+}
+
+impl<T> GposSubtableBuilder for T
+where
+    T: Default,
+    LookupBuilder<T>: Into<PositionLookup>,
+{
+    fn to_pos_lookup(
+        flags: LookupFlag,
+        filter_set: Option<FilterSetId>,
+        subtables: Vec<Self>,
+    ) -> ExternalGposLookup {
+        ExternalGposLookup(LookupBuilder::new_with_lookups(flags, filter_set, subtables).into())
+    }
+}

--- a/fea-rs/src/compile/features.rs
+++ b/fea-rs/src/compile/features.rs
@@ -222,6 +222,19 @@ impl AllFeatures {
         result
     }
 
+    //FIXME: what do we do with conflicts?
+    pub(crate) fn merge_external_features(
+        &mut self,
+        features: BTreeMap<FeatureKey, FeatureLookups>,
+    ) {
+        for (key, lookups) in features {
+            self.get_or_insert(key).base.extend(lookups.base);
+            if !lookups.variations.is_empty() {
+                panic!("specifying feature variations from feature writer is not yet supported");
+            }
+        }
+    }
+
     #[cfg(test)]
     fn get_base(&self, key: &FeatureKey) -> Option<&[LookupId]> {
         self.features.get(key).map(|x| x.base.as_slice())

--- a/fea-rs/src/compile/features.rs
+++ b/fea-rs/src/compile/features.rs
@@ -410,6 +410,7 @@ fn split_lookups(lookups: &[LookupId]) -> (Vec<u16>, Vec<u16>) {
             LookupId::Gpos(_) => gpos.push(lookup.to_gpos_id_or_die()),
             LookupId::Gsub(_) => gsub.push(lookup.to_gsub_id_or_die()),
             LookupId::Empty => (),
+            LookupId::External(_) => panic!("external lookups should not be present at split time"),
         }
     }
 

--- a/fea-rs/src/compile/language_system.rs
+++ b/fea-rs/src/compile/language_system.rs
@@ -8,6 +8,7 @@ use super::{lookups::FeatureKey, tags};
 
 /// A script/language pair
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[allow(missing_docs)]
 pub struct LanguageSystem {
     pub script: Tag,
     pub language: Tag,
@@ -36,13 +37,14 @@ impl DefaultLanguageSystems {
         self.items.contains(key)
     }
 
-    pub(crate) fn iter(&self) -> impl Iterator<Item = LanguageSystem> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = LanguageSystem> + '_ {
         self.items.iter().copied()
     }
 }
 
 impl LanguageSystem {
-    pub(crate) fn to_feature_key(self, feature: Tag) -> FeatureKey {
+    /// Generate a `FeatureKey` for this langauge system.
+    pub fn to_feature_key(self, feature: Tag) -> FeatureKey {
         let LanguageSystem { script, language } = self;
         FeatureKey {
             feature,

--- a/fea-rs/src/compile/lookups.rs
+++ b/fea-rs/src/compile/lookups.rs
@@ -40,10 +40,8 @@ use contextual::{
     SubChainContextBuilder, SubContextBuilder,
 };
 
-use gpos::{
-    CursivePosBuilder, MarkToBaseBuilder, MarkToLigBuilder, MarkToMarkBuilder, SinglePosBuilder,
-};
-pub use gpos::{PairPosBuilder, PreviouslyAssignedClass};
+use gpos::{CursivePosBuilder, MarkToLigBuilder, SinglePosBuilder};
+pub use gpos::{MarkToBaseBuilder, MarkToMarkBuilder, PairPosBuilder, PreviouslyAssignedClass};
 use gsub::{AlternateSubBuilder, LigatureSubBuilder, MultipleSubBuilder, SingleSubBuilder};
 pub(crate) use helpers::ClassDefBuilder2;
 

--- a/fea-rs/src/compile/lookups/gpos.rs
+++ b/fea-rs/src/compile/lookups/gpos.rs
@@ -108,6 +108,9 @@ fn cmp_coverage_key(coverage: &CoverageTable) -> impl Ord {
     (std::cmp::Reverse(coverage.len()), coverage.iter().next())
 }
 
+/// A builder for GPOS type 2 (PairPos) subtables
+///
+/// This builder can build both glyph and class-based kerning subtables.
 #[derive(Clone, Debug, Default)]
 pub struct PairPosBuilder {
     pairs: GlyphPairPosBuilder,
@@ -200,7 +203,8 @@ impl ClassPairPosSubtable {
 }
 
 impl PairPosBuilder {
-    pub(crate) fn insert_pair(
+    /// Insert a new kerning pair
+    pub fn insert_pair(
         &mut self,
         glyph1: GlyphId,
         record1: ValueRecord,
@@ -214,7 +218,8 @@ impl PairPosBuilder {
             .insert(glyph2, (record1, record2));
     }
 
-    pub(crate) fn insert_classes(
+    /// Insert a new class-based kerning rule.
+    pub fn insert_classes(
         &mut self,
         class1: GlyphClass,
         record1: ValueRecord,

--- a/fea-rs/src/compile/lookups/gpos.rs
+++ b/fea-rs/src/compile/lookups/gpos.rs
@@ -429,6 +429,7 @@ impl Builder for MarkList {
     }
 }
 
+/// A builder for GPOS Lookup Type 4, Mark-to-Base
 #[derive(Clone, Debug, Default)]
 pub struct MarkToBaseBuilder {
     marks: MarkList,
@@ -445,9 +446,11 @@ impl VariationIndexContainingLookup for MarkToBaseBuilder {
     }
 }
 
-/// An error indicating a given glyph is has be
+/// An error indicating a given glyph has been assigned to multiple mark classes
 pub struct PreviouslyAssignedClass {
+    /// The ID of the glyph in conflict
     pub glyph_id: GlyphId,
+    /// The name of the previous class
     pub class: SmolStr,
 }
 
@@ -465,15 +468,18 @@ impl MarkToBaseBuilder {
         self.marks.insert(glyph, class, anchor)
     }
 
+    /// Insert a new base glyph.
     pub fn insert_base(&mut self, glyph: GlyphId, class: &SmolStr, anchor: AnchorTable) {
         let class = self.marks.get_class(class);
         self.bases.entry(glyph).or_default().push((class, anchor))
     }
 
+    /// Returns an iterator over all of the base glyphs
     pub fn base_glyphs(&self) -> impl Iterator<Item = GlyphId> + Clone + '_ {
         self.bases.keys().copied()
     }
 
+    /// Returns an iterator over all of the mark glyphs
     pub fn mark_glyphs(&self) -> impl Iterator<Item = GlyphId> + Clone + '_ {
         self.marks.glyphs()
     }
@@ -587,6 +593,7 @@ impl Builder for MarkToLigBuilder {
     }
 }
 
+/// A builder for GPOS Type 6 (Mark-to-Mark)
 #[derive(Clone, Debug, Default)]
 pub struct MarkToMarkBuilder {
     attaching_marks: MarkList,
@@ -594,7 +601,11 @@ pub struct MarkToMarkBuilder {
 }
 
 impl MarkToMarkBuilder {
-    pub fn insert_mark(
+    /// Add a new mark1 (combining) glyph.
+    ///
+    /// If this glyph already exists in another mark class, we return the
+    /// previous class; this is likely an error.
+    pub fn insert_mark1(
         &mut self,
         glyph: GlyphId,
         class: SmolStr,
@@ -603,15 +614,18 @@ impl MarkToMarkBuilder {
         self.attaching_marks.insert(glyph, class, anchor)
     }
 
-    pub fn insert_base(&mut self, glyph: GlyphId, class: &SmolStr, anchor: AnchorTable) {
+    /// Insert a new mark2 (base) glyph
+    pub fn insert_mark2(&mut self, glyph: GlyphId, class: &SmolStr, anchor: AnchorTable) {
         let id = self.attaching_marks.get_class(class);
         self.base_marks.entry(glyph).or_default().push((id, anchor))
     }
 
+    /// Returns an iterator over all of the mark1 glyphs
     pub fn mark1_glyphs(&self) -> impl Iterator<Item = GlyphId> + Clone + '_ {
         self.attaching_marks.glyphs()
     }
 
+    /// Returns an iterator over all of the mark2 glyphs
     pub fn mark2_glyphs(&self) -> impl Iterator<Item = GlyphId> + Clone + '_ {
         self.base_marks.keys().copied()
     }

--- a/fea-rs/src/compile/tables/gdef.rs
+++ b/fea-rs/src/compile/tables/gdef.rs
@@ -21,8 +21,9 @@ use write_fonts::tables::{
 use super::{VariationIndexRemapping, VariationStoreBuilder};
 use crate::common::GlyphClass;
 
+/// Data collected from a GDEF block.
 #[derive(Clone, Debug, Default)]
-pub(crate) struct GdefBuilder {
+pub struct GdefBuilder {
     pub glyph_classes: HashMap<GlyphId, ClassId>,
     pub attach: BTreeMap<GlyphId, BTreeSet<u16>>,
     pub ligature_pos: BTreeMap<GlyphId, Vec<CaretValue>>,

--- a/fea-rs/src/lib.rs
+++ b/fea-rs/src/lib.rs
@@ -15,7 +15,7 @@ pub mod util;
 #[cfg(test)]
 mod tests;
 
-pub use common::{GlyphIdent, GlyphMap, GlyphName};
+pub use common::{GlyphClass, GlyphIdent, GlyphMap, GlyphName};
 pub use compile::Compiler;
 pub use diagnostic::{Diagnostic, Level};
 pub use parse::{ParseTree, TokenSet};


### PR DESCRIPTION
This PR is a start on providing API that allows the client to specify additional feature code at compile time, without needing to use FEA as an IR.

This involves:
- letting the client provide us with a `FeatureWriter` type during compilation
- calling this type after the compilation pass, but before assembling the final tables
- letting it add new lookups and features
- and merging these features and lookups into the overall set before building the final tables

It also involves making certain internal types public, such as some of our lookup builders.


This is a WIP. Currently unresolved:

- how we handle errors
- merging lookups in any way that is not just concatenation
- support for mark rules